### PR TITLE
docs: position relative to react-native-big-calendar

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,39 @@ A generic, themeable **month / week / day** calendar for React Native.
 - 🧩 Bring-your-own event type (`CalendarEvent<T>`) and a `renderEvent` escape hatch
 - 🎨 Fully themeable, with sensible defaults (no styling library required)
 
+## Relationship to react-native-big-calendar
+
+This is a ground-up reimagining inspired by the excellent
+[`react-native-big-calendar`](https://github.com/acro5piano/react-native-big-calendar).
+It keeps the familiar month/week/day model but is built around Reanimated and
+modern list virtualization — trading framework-agnosticism for a richer,
+gesture-driven experience. It's **not a fork**; the API differs, and the name is
+an homage. 🙇
+
+**What it adds**
+
+- 🤏 **Pinch-to-zoom** time grid — row height is a Reanimated shared value, so
+  zooming runs on the UI thread with zero React re-renders.
+- ♾️ **Virtualized, snap-paged** months/weeks/days (via `@legendapp/list`) — swipe
+  across years of dates, with native one-page paging (or opt into `freeSwipe`).
+- 🧩 **Generic events + render-prop _component_** — `CalendarEvent<T>` carries your
+  own fields, and `renderEvent` is a component (so it may use hooks) that
+  receives the event box's live pixel height for progressive disclosure as the
+  grid zooms.
+- 🗓️ **Multi-day events** clipped per day, with `continuesBefore`/`continuesAfter`
+  flags for continuation hints.
+- ⏱️ Hour windowing (`minHour`/`maxHour`), 12-hour labels (`ampm`), tap-an-empty-
+  slot (`onPressCell`), and a live now-indicator.
+
+**Trade-offs (where react-native-big-calendar may suit you better)**
+
+- It's **opinionated about peers**: Reanimated, Gesture Handler and
+  `@legendapp/list` are required. `react-native-big-calendar` is more
+  self-contained (no Reanimated/Gesture Handler).
+- It focuses on month/week/day. If you need a built-in agenda/schedule view, an
+  all-day event lane, or broad locale/RTL coverage today, `react-native-big-calendar`
+  is more mature on those fronts.
+
 ## Install
 
 ```sh


### PR DESCRIPTION
Adds a README section crediting [react-native-big-calendar](https://github.com/acro5piano/react-native-big-calendar) as the inspiration and honestly framing the differences (what this adds: pinch-zoom, virtualized paging, generic render-prop events, multi-day clipping, hour windowing) and the trade-offs (opinionated peers; big-calendar is more mature on agenda/all-day/locale).

Docs-only; no code or API changes.