### PR TITLE
fix(native): repaint mounted month pages when events or activeDate change

### DIFF
--- a/packages/native/src/components/MonthPager.tsx
+++ b/packages/native/src/components/MonthPager.tsx
@@ -206,6 +206,14 @@ function MonthPagerInner<T>({
     return isRTL ? days.reverse() : days;
   }, [anchor, weekStartsOn, isRTL]);
 
+  // Pages are keyed by month Dates that never change, so LegendList keeps the
+  // pages it has already rendered and only re-renders them when `data` or
+  // `extraData` changes — a new `renderItem` identity is not enough. Feed
+  // `events` (events that arrive after mount, e.g. from an async fetch, must
+  // repaint the mounted page) and `activeDate` (the selected-day highlight must
+  // move). Mirrors listExtraData in TimeGrid.
+  const listExtraData = useMemo(() => ({ events, activeDate }), [events, activeDate]);
+
   const snapToIndices = useMemo(() => monthDates.map((_, index) => index), [monthDates]);
   const keyExtractorList = useCallback((item: Date) => item.toISOString(), []);
   const getFixedItemSize = useCallback(() => containerWidth, [containerWidth]);
@@ -297,6 +305,7 @@ function MonthPagerInner<T>({
           ref={listRef}
           style={isWeb ? [styles.pagerList, styles.webNoScroll] : styles.pagerList}
           data={monthDates}
+          extraData={listExtraData}
           horizontal
           recycleItems={false}
           keyExtractor={keyExtractorList}

--- a/packages/native/src/components/__tests__/MonthPager.test.tsx
+++ b/packages/native/src/components/__tests__/MonthPager.test.tsx
@@ -1,0 +1,67 @@
+import { render } from "@testing-library/react-native";
+import type { CalendarEvent } from "../../types";
+
+// Capture the props handed to the virtualized list, and render only the active
+// page through `renderItem`. The real LegendList can't lay out under Jest (no
+// measured dimensions), so it never mounts page content; this stand-in does,
+// while still exposing the props we assert on.
+const lastListProps = () => (globalThis as { __listProps?: Record<string, unknown> }).__listProps;
+jest.mock("@legendapp/list/react-native", () => ({
+  __esModule: true,
+  LegendList: (props: any) => {
+    (globalThis as any).__listProps = props;
+    const index = props.initialScrollIndex ?? 0;
+    const item = props.data?.[index];
+    return item === undefined ? null : props.renderItem({ item, index });
+  },
+}));
+
+import { Calendar } from "../Calendar";
+
+type WithId = { id: string };
+const noop = () => {};
+
+describe("MonthPager event updates", () => {
+  // Pages are keyed by month Dates that never change, so a mounted page only
+  // repaints when the list's `data` or `extraData` changes. Events supplied
+  // after mount (the usual async fetch) change neither — so without feeding
+  // `events` to the list as extraData, the month grid stays empty until the
+  // pager remounts. Guard the wiring that makes external updates repaint.
+  it("feeds the current events to the list as extraData", () => {
+    const date = new Date(2026, 0, 6, 12, 0, 0);
+    const initialEvents: CalendarEvent<WithId>[] = [];
+    const { rerender, getByLabelText, queryByLabelText } = render(
+      <Calendar
+        mode="month"
+        date={date}
+        events={initialEvents}
+        onChangeDate={noop}
+        onPressEvent={noop}
+      />,
+    );
+    expect((lastListProps()?.extraData as { events?: unknown })?.events).toBe(initialEvents);
+    expect(queryByLabelText(/6 January 2026, 1 event$/)).toBeNull();
+
+    // The fetch resolves after the pager (and its pages) mounted.
+    const fetched: CalendarEvent<WithId>[] = [
+      {
+        id: "1",
+        start: new Date(2026, 0, 6, 9, 0, 0),
+        end: new Date(2026, 0, 6, 10, 0, 0),
+        title: "Standup",
+      },
+    ];
+    rerender(
+      <Calendar
+        mode="month"
+        date={date}
+        events={fetched}
+        onChangeDate={noop}
+        onPressEvent={noop}
+      />,
+    );
+
+    expect((lastListProps()?.extraData as { events?: unknown })?.events).toBe(fetched);
+    expect(getByLabelText(/6 January 2026, 1 event$/)).toBeTruthy();
+  });
+});


### PR DESCRIPTION
Fixes #28

### Problem

In month mode, events supplied after mount (the usual async-fetch flow) never render — the month grid stays empty until the pager remounts (e.g. swiping away and back). Likewise, the selected-day highlight doesn't move on an already-mounted page when `activeDate` changes.

`MonthPager` renders its month pages through LegendList with pages keyed by month `Date`s that never change, and passed no `extraData`. LegendList keeps mounted rows and only re-renders them when `data` or `extraData` changes — a new `renderItem` identity is not enough — so pages painted at mount kept rendering the `events` and `activeDate` captured at that time.

### Fix

Feed `{ events, activeDate }` to the list as `extraData`, mirroring the existing `listExtraData` in `TimeGrid` and the `extraData` in both `MonthList` renderers. `MonthPager` was the only events-rendering LegendList without it.

### Test

Added `MonthPager.test.tsx` following the pattern of the existing `TimeGrid.test.tsx` extraData guard (mock LegendList, capture its props, assert the current `events` array is wired through as `extraData` across a rerender). The test fails on `main` and passes with this change.

`pnpm lint`, `pnpm format`, `pnpm typecheck`, and `pnpm test` (337 tests / 30 suites) all pass. No public API change.

We've been shipping this fix in production as a `patch-package` patch on `@super-calendar/native` 2.1.5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
