### PR TITLE
fix(native): type each slot for the element it styles

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,5 +56,5 @@
     "tsdown": "^0.22.8",
     "typescript": "^6.0.3"
   },
-  "packageManager": "pnpm@11.13.0"
+  "packageManager": "pnpm@11.21.0"
 }

--- a/packages/native/src/components/Agenda.tsx
+++ b/packages/native/src/components/Agenda.tsx
@@ -1,7 +1,7 @@
 import { LegendList, type LegendListRenderItemProps } from "@legendapp/list/react-native";
 import { format, isSameDay, type Locale, startOfDay } from "date-fns";
 import { type ComponentType, type ReactElement, useCallback, useMemo } from "react";
-import { StyleSheet, Text, View } from "react-native";
+import { StyleSheet, Text, type TextStyle, View } from "react-native";
 import { useCalendarTheme } from "../theme";
 import type { CalendarEvent, EventKeyExtractor, RenderEvent } from "../types";
 import { createSlots, type SlotStyleProps } from "../utils/slots";
@@ -83,7 +83,7 @@ export function Agenda<T>({
         const isHighlighted = activeDate ? isSameDay(item.date, activeDate) : getIsToday(item.date);
         return (
           <Text
-            {...slot("dayHeader", {
+            {...slot<TextStyle>("dayHeader", {
               base: styles.header,
               themed: [
                 styles.headerText,
@@ -124,7 +124,7 @@ export function Agenda<T>({
   if (rows.length === 0) {
     return (
       <Text
-        {...slot("empty", {
+        {...slot<TextStyle>("empty", {
           base: styles.empty,
           themed: [styles.emptyText, { color: theme.colors.textMuted }],
         })}

--- a/packages/native/src/components/AllDayLane.tsx
+++ b/packages/native/src/components/AllDayLane.tsx
@@ -1,5 +1,5 @@
 import { addDays, startOfDay } from "date-fns";
-import { StyleSheet, Text, View } from "react-native";
+import { StyleSheet, Text, type TextStyle, View } from "react-native";
 import { useCalendarTheme } from "../theme";
 import type { CalendarEvent, CalendarMode, EventKeyExtractor, RenderEvent } from "../types";
 import { useSlots } from "../utils/slots";
@@ -64,7 +64,7 @@ export function AllDayLane<T>({
             and right-aligned against the timed columns. Centered vertically so it
             lines up with the chips whether the lane holds one event or several. */}
         <Text
-          {...slot("allDayLabel", {
+          {...slot<TextStyle>("allDayLabel", {
             base: styles.label,
             themed: { color: theme.colors.textMuted },
           })}

--- a/packages/native/src/components/MonthList.tsx
+++ b/packages/native/src/components/MonthList.tsx
@@ -21,6 +21,7 @@ import {
   StyleSheet,
   type StyleProp,
   Text,
+  type TextStyle,
   View,
   type ViewStyle,
 } from "react-native";
@@ -440,7 +441,7 @@ function MonthListInner<T>({
             renderMonthHeader(item)
           ) : (
             <Text
-              {...slot("title", {
+              {...slot<TextStyle>("title", {
                 base: styles.monthTitle,
                 themed: [styles.monthTitleText, { color: theme.colors.text }],
               })}
@@ -560,7 +561,7 @@ function MonthListInner<T>({
           {weekDays.map((day) => (
             <Text
               key={day.toISOString()}
-              {...slot("weekday", {
+              {...slot<TextStyle>("weekday", {
                 base: styles.weekdayLabel,
                 themed: [styles.weekdayLabelText, { color: theme.colors.textMuted }],
               })}

--- a/packages/native/src/components/MonthPager.tsx
+++ b/packages/native/src/components/MonthPager.tsx
@@ -11,6 +11,7 @@ import {
   StyleSheet,
   type StyleProp,
   Text,
+  type TextStyle,
   useWindowDimensions,
   View,
   type ViewStyle,
@@ -304,7 +305,7 @@ function MonthPagerInner<T>({
       {/* The active month's title, above the (shared) weekday header — mirrors the
           dom MonthView's title. The grids below omit their own title/weekdays. */}
       <Text
-        {...slot("title", {
+        {...slot<TextStyle>("title", {
           base: styles.monthTitle,
           themed: [theme.text.monthTitle, { color: theme.colors.text }],
         })}
@@ -411,7 +412,7 @@ const MonthWeekdayHeader = ({
       {weekDays.map((day) => (
         <Text
           key={day.toISOString()}
-          {...slot("weekday", {
+          {...slot<TextStyle>("weekday", {
             base: styles.weekdayLabel,
             themed: [theme.text.weekday, { color: theme.colors.textMuted }],
           })}

--- a/packages/native/src/components/MonthView.tsx
+++ b/packages/native/src/components/MonthView.tsx
@@ -10,6 +10,7 @@ import {
   StyleSheet,
   type StyleProp,
   Text,
+  type TextStyle,
   TouchableOpacity,
   View,
   type ViewStyle,
@@ -531,7 +532,9 @@ function MonthViewInner<T>({
             })}
           >
             <Text
-              {...slot("dayBadgeText", { themed: [theme.text.dateCell, { color: dateColor }] })}
+              {...slot<TextStyle>("dayBadgeText", {
+                themed: [theme.text.dateCell, { color: dateColor }],
+              })}
               allowFontScaling={false}
             >
               {format(day, "d")}
@@ -549,7 +552,7 @@ function MonthViewInner<T>({
         ))}
         {hiddenCount > 0 ? (
           <Text
-            {...slot("more", {
+            {...slot<TextStyle>("more", {
               base: styles.moreLabel,
               themed: [theme.text.more, { color: theme.colors.textMuted }],
             })}
@@ -578,7 +581,7 @@ function MonthViewInner<T>({
     <View style={styles.root}>
       {showTitle ? (
         <Text
-          {...slot("title", {
+          {...slot<TextStyle>("title", {
             base: styles.title,
             themed: [theme.text.monthTitle, { color: theme.colors.text }],
           })}
@@ -597,7 +600,7 @@ function MonthViewInner<T>({
           {weekdayLabels.map((day) => (
             <Text
               key={day.toISOString()}
-              {...slot("weekday", {
+              {...slot<TextStyle>("weekday", {
                 base: styles.weekdayLabel,
                 themed: [theme.text.weekday, { color: theme.colors.textMuted }],
               })}

--- a/packages/native/src/components/TimeGrid.tsx
+++ b/packages/native/src/components/TimeGrid.tsx
@@ -34,6 +34,7 @@ import {
   StyleSheet,
   type StyleProp,
   Text,
+  type TextStyle,
   useWindowDimensions,
   View,
   type ViewStyle,
@@ -842,7 +843,7 @@ const HourRow = ({
         <View style={{ width: hourColumnWidth }}>{hourComponent(hour, ampm)}</View>
       ) : (
         <Text
-          {...slot("hourLabel", {
+          {...slot<TextStyle>("hourLabel", {
             base: [styles.hourLabel, { width: hourColumnWidth }],
             themed: [theme.text.hourLabel, { color: theme.colors.textMuted }],
           })}
@@ -2557,7 +2558,7 @@ const DefaultHeader = ({
       <View style={[styles.weekNumberGutter, { width: hourColumnWidth }]}>
         {showWeekNumber && hourColumnWidth > 0 && days[0] ? (
           <Text
-            {...slot("weekNumber", {
+            {...slot<TextStyle>("weekNumber", {
               themed: [theme.text.hourLabel, { color: theme.colors.textMuted }],
             })}
             allowFontScaling={false}
@@ -2623,7 +2624,7 @@ const DayHeader = ({
   const content = (
     <>
       <Text
-        {...slot("columnHeaderWeekday", {
+        {...slot<TextStyle>("columnHeaderWeekday", {
           themed: [{ color: theme.colors.textMuted }, theme.text.columnHeaderWeekday],
         })}
         allowFontScaling={false}
@@ -2641,7 +2642,7 @@ const DayHeader = ({
         })}
       >
         <Text
-          {...slot("columnHeaderDateText", {
+          {...slot<TextStyle>("columnHeaderDateText", {
             themed: [
               theme.text.dayNumber,
               // The state colour stays last so a themed dayNumber can't break the

--- a/packages/native/src/components/YearView.tsx
+++ b/packages/native/src/components/YearView.tsx
@@ -6,6 +6,7 @@ import {
   ScrollView,
   StyleSheet,
   Text,
+  type TextStyle,
   View,
 } from "react-native";
 import { useCalendarTheme } from "../theme";
@@ -117,7 +118,7 @@ function YearViewInner<T>({
           const monthLabel = format(month, "MMMM yyyy", { locale });
           const titleText = (
             <Text
-              {...slot("monthTitle", {
+              {...slot<TextStyle>("monthTitle", {
                 base: styles.monthTitle,
                 themed: [styles.monthTitleText, { color: theme.colors.todayBackground }],
               })}
@@ -155,7 +156,7 @@ function YearViewInner<T>({
                 {weekdayLabels.map((label, i) => (
                   <Text
                     key={i}
-                    {...slot("weekday", {
+                    {...slot<TextStyle>("weekday", {
                       base: styles.weekday,
                       themed: [styles.weekdayText, { color: theme.colors.textMuted }],
                     })}
@@ -192,7 +193,7 @@ function YearViewInner<T>({
                     const content = (
                       <>
                         <Text
-                          {...slot("dayText", {
+                          {...slot<TextStyle>("dayText", {
                             themed: [
                               styles.dayText,
                               {

--- a/packages/native/src/utils/slots.ts
+++ b/packages/native/src/utils/slots.ts
@@ -15,7 +15,17 @@
 // prop React Native silently ignores, so the props are safe to pass everywhere.
 
 import { createContext, createElement, type ReactNode, useContext, useMemo } from "react";
-import type { StyleProp, TextStyle } from "react-native";
+import type { ImageStyle, StyleProp, TextStyle, ViewStyle } from "react-native";
+
+/**
+ * The style shapes a slot can resolve to. A slot carries the style type of the
+ * element it is spread on, because React Native's style types stop being
+ * mutually assignable as soon as a consumer's types diverge them: Expo's
+ * react-native-web types widen `cursor` on `TextStyle` and `userSelect` on
+ * `ViewStyle`, so a `View` slot typed as `TextStyle` fails to compile in any
+ * Expo app.
+ */
+export type SlotStyle = ViewStyle | TextStyle | ImageStyle;
 
 /**
  * Per-slot styling overrides. Give a slot a Tailwind class (uniwind/NativeWind)
@@ -30,20 +40,20 @@ export interface SlotStyleProps<Slot extends string> {
    */
   classNames?: Partial<Record<Slot, string>>;
   /** Style overrides per slot, merged last (win over defaults and classes). */
-  styles?: Partial<Record<Slot, StyleProp<TextStyle>>>;
+  styles?: Partial<Record<Slot, StyleProp<SlotStyle>>>;
 }
 
 /** A slot's built-in styling, split so classes can replace the look but not the layout. */
-export interface SlotDefault {
+export interface SlotDefault<Style extends SlotStyle = ViewStyle> {
   /** Structural styles kept even when a class is supplied. */
-  base?: StyleProp<TextStyle>;
+  base?: StyleProp<Style>;
   /** Themed styles (colour, type, spacing) dropped when a class is supplied. */
-  themed?: StyleProp<TextStyle>;
+  themed?: StyleProp<Style>;
 }
 
 /** The props a resolved slot spreads onto an element. */
-export interface ResolvedSlot {
-  style: StyleProp<TextStyle>;
+export interface ResolvedSlot<Style extends SlotStyle = ViewStyle> {
+  style: StyleProp<Style>;
   className?: string;
 }
 
@@ -53,10 +63,24 @@ export interface ResolvedSlot {
  * consumer supplied one, a `className` for the Tailwind runtime to pick up.
  */
 export function createSlots<Slot extends string>({ classNames, styles }: SlotStyleProps<Slot>) {
-  return (name: Slot, defaults?: SlotDefault): ResolvedSlot => {
+  // `NoInfer` keeps the element type a decision, not a guess: without it the
+  // literal type of a `StyleSheet.create` entry wins the inference and every
+  // themed style passed alongside it is then measured against that one entry.
+  // Slots default to a `View`; `slot<TextStyle>(...)` marks the text ones.
+  return <Style extends SlotStyle = ViewStyle>(
+    name: Slot,
+    defaults?: SlotDefault<NoInfer<Style>>,
+  ): ResolvedSlot<Style> => {
     const slotClass = classNames?.[name];
     return {
-      style: [defaults?.base, slotClass ? undefined : defaults?.themed, styles?.[name]],
+      style: [
+        defaults?.base,
+        slotClass ? undefined : defaults?.themed,
+        // A consumer's override is declared for any element's style, so it is
+        // narrowed to this slot's element here. React Native flattens the array
+        // and drops properties the element does not support either way.
+        styles?.[name] as StyleProp<Style>,
+      ],
       ...(slotClass ? { className: slotClass } : null),
     };
   };

--- a/tests/types/react-native-style-divergence.d.ts
+++ b/tests/types/react-native-style-divergence.d.ts
@@ -1,0 +1,24 @@
+// A consumer's type environment can pull React Native's style types apart, and
+// a slot typed for the wrong element then stops compiling in *their* app, where
+// they cannot fix it. Expo does exactly this: every Expo app references
+// `expo/types` through a generated `expo-env.d.ts`, and its react-native-web
+// declarations widen `cursor` on `TextStyle` and `userSelect` on `ViewStyle`,
+// which leaves the two mutually unassignable.
+//
+// Mirroring that divergence here puts it in front of `pnpm typecheck`, so a
+// `View` slot typed as `TextStyle` fails in this repo instead of downstream.
+// This fixture is only ever type-checked; it is not part of any published
+// package, and the exact properties matter less than the divergence itself.
+export {};
+
+declare module "react-native" {
+  interface ViewStyle {
+    /** @platform web */
+    userSelect?: string;
+  }
+
+  interface TextStyle {
+    /** @platform web */
+    cursor?: string;
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -22,6 +22,6 @@
       "@super-calendar/dom": ["./packages/dom/src/index.ts"]
     }
   },
-  "include": ["packages/*/src"],
+  "include": ["packages/*/src", "tests/types"],
   "exclude": ["**/dist", "**/node_modules"]
 }


### PR DESCRIPTION
## What

Every slot resolved by `createSlots` was typed `StyleProp<TextStyle>`, including the ones spread onto `View`, `Pressable` and `ScrollView`. That compiles only while React Native's `ViewStyle` and `TextStyle` stay mutually assignable, which is an accident of both being all-optional rather than something we can rely on.

Expo breaks it. Every Expo app generates a gitignored `expo-env.d.ts` referencing `expo/types`, whose `react-native-web.d.ts` widens `cursor` to `string` on `TextStyle` and `userSelect` to `string` on `ViewStyle`. The two types then diverge in both directions and **46 type errors appear inside this library's own sources, in the consumer's build**, where they cannot fix them. Found while consuming 2.8.1 from an Expo app.

## How

Slots now carry the style type of the element they are spread on:

- `SlotDefault<Style>` and `ResolvedSlot<Style>` are generic over `SlotStyle = ViewStyle | TextStyle | ImageStyle`, defaulting to `ViewStyle`.
- The resolver parameter uses `NoInfer<Style>`. Without it the literal type of a `StyleSheet.create` entry wins inference, and every themed style passed alongside it gets measured against that one entry (58 errors of exactly that shape when I tried it).
- The 18 genuinely-text slots are annotated `slot<TextStyle>("hourLabel", …)` across seven components.
- The consumer-facing `styles` override map widens from `StyleProp<TextStyle>` to `StyleProp<SlotStyle>`, so a container slot can take a `ViewStyle`. One documented assertion narrows that override onto the slot's element type inside the resolver.

Backwards compatible: nothing removed, both public interfaces gained a defaulted type parameter, and the override map only got wider.

## Regression guard

CI could not see this for two independent reasons. The example app never has `expo-env.d.ts` (gitignored, only written by `expo start`), so `expo/types` was absent from its program. And even after adding the reference it changed nothing, because with identical `moduleResolution` and `customConditions`, TypeScript applies Expo's `declare module "react-native"` augmentation under `module: "esnext"` but not under `module: "preserve"`, which is what `expo/tsconfig.base` sets.

So instead of depending on that quirk, `tests/types/react-native-style-divergence.d.ts` mirrors the divergence as a checked fixture (never published) and `tests/types` joins the root tsconfig `include`, putting it in front of the existing `pnpm typecheck` in CI and the pre-commit hook. Red/green tested: **64 errors** with the old `slots.ts`, **0** with this change.

## Verification

Ground truth was the real consumer, since neither the example app nor `pnpm typecheck` reproduced it before this PR. I swapped the fixed sources into that app's installed copy of 2.8.1 and re-ran its typecheck: **46 errors to 0**, then restored the published state and confirmed it returned to 46.

`tsc --noEmit`, oxlint, oxfmt clean. 471 tests across 37 suites pass. The example app typechecks under both module settings.

## Also here

`packageManager` was pinned to `pnpm@11.13.0`, a broken release that pnpm refuses to run ("its @pnpm/exe build shipped without a binary"), so `pnpm typecheck`, `pnpm test` and every pre-commit hook failed before doing anything. Bumped to 11.21.0 in its own commit.