### PR TITLE
feat(month): hide the built-in title, and add cell press and drag support

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ partial-weeks) / **agenda (`schedule`)** modes, **all-day events** (lane +
 `minHour`/`maxHour`, `ampm` (hour axis and event times), `showTime`, `timeslots`,
 `hideHours`, `showWeekNumber`, `weekNumberPrefix`, `hourComponent`,
 `sortedMonthView`, `moreLabel`, `showAdjacentMonths`, `showSixWeeks`,
+`showTitle` (hide the built-in month label when your own header shows it),
 `disableMonthEventCellPress`, a default month weekday header
 (`renderHeaderForMonthView`), a custom month date badge
 (`renderCustomDateForMonth`), `activeDate`, per-event
@@ -361,6 +362,28 @@ cancels an in-progress sweep before it commits.
 />
 ```
 
+**On the month grid.** Both handlers also work in `mode="month"`, on both
+renderers. `onCreateEvent` sweeps across day cells to create an **all-day** span
+(`start` at midnight of the first day, `end` at midnight after the last), and
+`onDragEvent` drops an event bar on another day, shifting both ends by the days
+dragged so the **time of day and duration are preserved**. Grab with a
+**long-press** on native, a **press-drag** on web. The same locks apply
+(`draggable`, `startEditable`, `eventStartEditable`, `eventOverlap`, and
+returning `false` to reject); there is no resize on the month grid.
+
+```tsx
+<Calendar
+  mode="month"
+  /* ... */
+  onCreateEvent={(start, end) =>
+    setEvents((prev) => [...prev, { id: makeId(), title: "New", start, end, allDay: true }])
+  }
+  onDragEvent={(event, start, end) =>
+    setEvents((prev) => prev.map((e) => (e.id === event.id ? { ...e, start, end } : e)))
+  }
+/>
+```
+
 ### Recurring events
 
 Give an event a `recurrence` rule and expand it into concrete occurrences for the
@@ -589,6 +612,8 @@ paging follows the system scroll direction — so enable React Native's
 - `ampm` switches hour labels to 12-hour AM/PM (default 24h).
 - `onPressCell(date)` fires when empty grid space is tapped, with the date+time
   under the touch — handy for "create event". (Event taps still go to `onPressEvent`.)
+  In `month` mode it fires for a day cell too, with that day at midnight, so one
+  handler covers every view; `onPressDay` still fires alongside it for drill-down.
 - **Long-press** mirrors every tap: `onLongPressEvent(event)`, `onLongPressCell(date)`
   (week/day), and `onLongPressDay(date)` (month). All optional.
 - **All-day events** render in a lane above the time grid (and as chips or

--- a/docs/guides/dragging.mdx
+++ b/docs/guides/dragging.mdx
@@ -4,8 +4,10 @@ sidebarTitle: Drag & create
 description: Move, resize, reschedule across days, and create events by dragging.
 ---
 
-All of this lives on the week/day grid and is opt-in: pass the relevant handler
-and update your own event state in response.
+Everything here is opt-in: pass the relevant handler and update your own event
+state in response. Move, resize, and create work on the week/day grid; move and
+create also work on the month grid (see [On the month grid](#on-the-month-grid)),
+where a drag moves an event by whole days rather than by time.
 
 ## Move and resize
 
@@ -174,13 +176,18 @@ in-progress sweep before it commits.
   "drag to create a range."
 </Note>
 
-### On the month grid
+## On the month grid
 
-`onCreateEvent` also works in `month` mode (web): press a day and drag across others
-to sketch an **all-day** span, then release. `start` is midnight of the first day and
-`end` is midnight after the last (exclusive). A plain click still fires `onPressDay`,
-and each day in the sweep carries `data-creating` for styling (see
-[Styling](/guides/styling)).
+The same two handlers work in `month` mode on both renderers. Nothing extra to
+enable: pass `onCreateEvent`, `onDragEvent`, or both.
+
+### Drag to create a day span
+
+Press an empty day and drag across others to sketch an **all-day** span, then
+release. `start` is midnight of the first day and `end` is midnight after the last
+(exclusive). On native you **long-press** first, so a tap and a page swipe are
+never hijacked, and a stationary hold creates that single day; on web a plain
+click without dragging creates nothing and still fires `onPressDay`.
 
 ```tsx
 <Calendar
@@ -191,6 +198,39 @@ and each day in the sweep carries `data-creating` for styling (see
   }
 />
 ```
+
+### Drag to reschedule
+
+Pick an event bar up and drop it on another day. Both ends shift by the same
+number of calendar days, so the **time of day and the duration are preserved**
+(a multi-day event keeps its length). Grab it with a **long-press** on native and
+a **press-drag** on web. The carried bar fades and the target day is tinted while
+you drag.
+
+```tsx
+<Calendar
+  mode="month"
+  /* ... */
+  onDragEvent={(event, start, end) =>
+    setEvents((prev) => prev.map((e) => (e.id === event.id ? { ...e, start, end } : e)))
+  }
+/>
+```
+
+Everything above applies here too: `draggable: false` and `startEditable: false`
+lock an event, `eventStartEditable={false}` locks the whole grid, returning
+`false` rejects a drop, and `eventOverlap={false}` rejects one that would land on
+top of another event. `onDragStart` fires on grab, for haptics. There is no resize
+on the month grid, so `durationEditable` has no effect there.
+
+### Styling the drag states
+
+Both states are tinted with the theme's `rangeBackground` token by default (see
+[Theming](/guides/theming)), and the bar being carried fades. On the dom renderer
+each day in a create sweep also carries `data-creating` and the day an event is
+about to land on carries `data-drop`, so you can restyle either (see
+[Styling](/guides/styling)); give the `day` slot a class to take the tint over
+entirely.
 
 ## Tuning the snap
 

--- a/docs/guides/month-view.mdx
+++ b/docs/guides/month-view.mdx
@@ -51,6 +51,9 @@ the rest of a day's events into a `+N more` label.
 
 ## Grid shape
 
+- `showTitle` — the built-in "July 2026" label above the grid (default on). Set
+  `showTitle={false}` when your own header already shows the month and year, so
+  the label isn't duplicated.
 - `showSixWeeks` — always render six week rows for a fixed-height grid.
 - `showAdjacentMonths` — show (dimmed) days from the neighbouring months
   (default on).
@@ -67,10 +70,32 @@ the rest of a day's events into a `+N more` label.
 ## Taps and custom cells
 
 `onPressDay` / `onLongPressDay` fire for the cell, `onPressEvent` /
-`onLongPressEvent` for a chip. Replace parts of the cell with
-`renderCustomDateForMonth` (the date badge) or a custom `renderEvent`
-(see [Custom events](/guides/events)); restyle everything else through the
-[theme](/guides/theming) or per-slot [classes](/guides/styling).
+`onLongPressEvent` for a chip. `onPressCell` fires for the cell too, with the day
+at midnight, so the handler you already use to create events on the week/day grid
+works unchanged in month mode:
+
+```tsx
+<Calendar
+  mode="month"
+  /* ... */
+  onPressCell={(day) => openNewAppointment(day)} // midnight of the tapped day
+  onPressDay={(day) => {
+    setDate(day);
+    setMode("day");
+  }}
+/>
+```
+
+Replace parts of the cell with `renderCustomDateForMonth` (the date badge) or a
+custom `renderEvent` (see [Custom events](/guides/events)); restyle everything
+else through the [theme](/guides/theming) or per-slot [classes](/guides/styling).
+
+## Dragging
+
+Month cells and chips are draggable too: pass `onCreateEvent` to sweep out an
+all-day span across days, and `onDragEvent` to drop an event on another day
+(keeping its time of day and duration). See
+[Drag & create](/guides/dragging#on-the-month-grid).
 
 Looking for a vertically scrolling list of months instead of a pager, or an
 events-free month grid for picking dates? That's [MonthList](/guides/month-list).

--- a/docs/guides/styling.mdx
+++ b/docs/guides/styling.mdx
@@ -134,6 +134,7 @@ variant works on either slot (e.g. `dayBadge: "data-[today]:bg-blue-600"`).
 | `data-outside`  | day / badge       | the day belongs to an adjacent month    |
 | `data-disabled` | day / badge       | the day is disabled (`min`/`maxDate`)   |
 | `data-creating` | day / badge       | the day is inside a drag-to-create span |
+| `data-drop`     | day / badge       | a dragged event would land on this day  |
 | `data-dragging` | time-grid event   | the event is being dragged              |
 
 Every slotted element also carries a stable `data-slot="<name>"` attribute, handy for

--- a/docs/reference/api.mdx
+++ b/docs/reference/api.mdx
@@ -52,16 +52,16 @@ your editor lists the full set with inline docs.
 
 | Prop                    | Type                                     | Notes                                                                             |
 | ----------------------- | ---------------------------------------- | --------------------------------------------------------------------------------- |
-| `onDragEvent`           | `(event, start, end) => void \| boolean` | Enable move/resize; return `false` to reject.                                     |
+| `onDragEvent`           | `(event, start, end) => void \| boolean` | Enable move/resize; return `false` to reject. Month: drop on another day.         |
 | `onDragStart`           | `(event) => void`                        | Fires on grab (e.g. haptics).                                                     |
-| `onCreateEvent`         | `(start, end) => void`                   | Drag empty space to create.                                                       |
+| `onCreateEvent`         | `(start, end) => void`                   | Drag empty space to create. Month: an all-day span.                               |
 | `dragStepMinutes`       | `number`                                 | Snap step (default 15).                                                           |
 | `showDragHandle`        | `boolean`                                | Show the resize grip (default true).                                              |
 | `eventStartEditable`    | `boolean`                                | Grid-wide: allow moving events (default true). Per-event `startEditable`.         |
 | `eventDurationEditable` | `boolean`                                | Grid-wide: allow resizing events (default true). Per-event `durationEditable`.    |
 | `eventOverlap`          | `boolean`                                | When false, reject a drag/resize that would overlap another event (default true). |
 | `onPressEvent`          | `(event) => void`                        | Tap an event.                                                                     |
-| `onPressCell`           | `(date) => void`                         | Tap empty grid space.                                                             |
+| `onPressCell`           | `(date) => void`                         | Tap empty grid space. Month: the tapped day at midnight.                          |
 | `onPressDay`            | `(date) => void`                         | Tap a month day cell.                                                             |
 | `onPressMore`           | `(events, date) => void`                 | Tap the `+N more` overflow.                                                       |
 
@@ -85,6 +85,7 @@ and `minDate` / `maxDate` / `isDateDisabled` for disabled days. See the
 | `allDayLabel`          | `string`                                   | Schedule all-day text ("All day").                                              |
 | `highlightWeekends`    | `boolean`                                  | Tint weekend cells/columns (month + time grid, default on).                     |
 | `maxVisibleEventCount` | `number`                                   | Month: fixed cap on event lanes per week row.                                   |
+| `showTitle`            | `boolean`                                  | Month: the built-in "MMMM yyyy" label above the grid (default on).              |
 | `theme`                | `PartialCalendarTheme`                     | Color/text/metric overrides.                                                    |
 | `classNames`           | `Partial<Record<CalendarSlot, string>>`    | Per-slot Tailwind classes (uniwind/NativeWind); see [Styling](/guides/styling). |
 | `styles`               | `Partial<Record<CalendarSlot, StyleProp>>` | Per-slot style overrides, merged last.                                          |

--- a/docs/reference/renderers.mdx
+++ b/docs/reference/renderers.mdx
@@ -31,6 +31,7 @@ CSS), not missing functionality.
 | Capability                     | native | dom | Notes                                                                                          |
 | ------------------------------ | :----: | :-: | ---------------------------------------------------------------------------------------------- |
 | Drag to move / resize / create |   ✅   | ✅  | native: long-press + gesture; dom: pointer.                                                    |
+| Month drag (create / move day) |   ✅   | ✅  | Sweep an all-day span, or drop an event on another day. Resize is time-grid only.              |
 | Pinch / scroll to zoom         |   ✅   | ✅  | native: pinch; dom: pinch + Ctrl/⌘-scroll (`zoomable`).                                        |
 | Controlled navigation          |   ✅   | ✅  | both fire `onChangeDate` — native on swipe/paging, dom on PageDown/PageUp of the focused grid. |
 | RTL layout                     |   ✅   | ❌  | native `isRTL` (cosmetic).                                                                     |

--- a/jest.setup.components.js
+++ b/jest.setup.components.js
@@ -5,10 +5,25 @@
 // registered under Jest. Mock the bits our grid uses: a passthrough
 // GestureDetector and a chainable Gesture builder (every method returns the
 // builder, so `Gesture.Pan().enabled(x).onStart(fn)` works without natives).
+// Each builder also records the callbacks it is given, and every builder made
+// during a test is pushed to `__gestures`, so a test can drive a gesture
+// directly: `__gestures.at(-1).handlers.onStart({ x, y })`.
 jest.mock("react-native-gesture-handler", () => {
   const { View } = require("react-native");
+  const gestures = [];
   const makeChain = () => {
-    const chain = new Proxy(() => chain, { get: () => () => chain });
+    const handlers = {};
+    const chain = new Proxy(() => chain, {
+      get: (_target, prop) =>
+        prop === "handlers"
+          ? handlers
+          : (...args) => {
+              const callback = args.find((arg) => typeof arg === "function");
+              if (callback) handlers[prop] = callback;
+              return chain;
+            },
+    });
+    gestures.push(chain);
     return chain;
   };
   return {
@@ -16,6 +31,7 @@ jest.mock("react-native-gesture-handler", () => {
     GestureDetector: ({ children }) => children,
     GestureHandlerRootView: View,
     Gesture: new Proxy({}, { get: () => () => makeChain() }),
+    __gestures: gestures,
   };
 });
 

--- a/packages/core/src/utils/__tests__/drag.test.ts
+++ b/packages/core/src/utils/__tests__/drag.test.ts
@@ -2,6 +2,8 @@ import type { CalendarEvent } from "../../types";
 import {
   cellRangeFromDrag,
   eventsOverlap,
+  monthCreateRange,
+  monthDropBounds,
   overlapsOtherEvents,
   pageStepDays,
   resolveDraggedBounds,
@@ -210,5 +212,60 @@ describe("cellRangeFromDrag", () => {
   it("returns null for a degenerate grid", () => {
     expect(cellRangeFromDrag(day, 100, 200, 0, 0, 15)).toBeNull();
     expect(cellRangeFromDrag(day, 100, 200, 64, 0, 0)).toBeNull();
+  });
+});
+
+describe("monthCreateRange", () => {
+  it("spans the swept days, ending at midnight after the last", () => {
+    const range = monthCreateRange(new Date(2026, 6, 6, 13, 30), new Date(2026, 6, 8, 4));
+    expect(range.start).toEqual(new Date(2026, 6, 6));
+    expect(range.end).toEqual(new Date(2026, 6, 9));
+  });
+
+  it("orders a backwards sweep the same way", () => {
+    const forward = monthCreateRange(new Date(2026, 6, 6), new Date(2026, 6, 8));
+    const backward = monthCreateRange(new Date(2026, 6, 8), new Date(2026, 6, 6));
+    expect(backward).toEqual(forward);
+  });
+
+  it("yields a single whole day when the sweep never leaves its cell", () => {
+    const range = monthCreateRange(new Date(2026, 6, 6, 9), new Date(2026, 6, 6, 17));
+    expect(range.start).toEqual(new Date(2026, 6, 6));
+    expect(range.end).toEqual(new Date(2026, 6, 7));
+  });
+});
+
+describe("monthDropBounds", () => {
+  const event: CalendarEvent = {
+    title: "Standup",
+    start: new Date(2026, 6, 6, 9, 30),
+    end: new Date(2026, 6, 6, 10, 15),
+  };
+
+  it("shifts both ends by the days dragged, keeping the time of day", () => {
+    const next = monthDropBounds(event, new Date(2026, 6, 6), new Date(2026, 6, 9));
+    expect(next?.start).toEqual(new Date(2026, 6, 9, 9, 30));
+    expect(next?.end).toEqual(new Date(2026, 6, 9, 10, 15));
+  });
+
+  it("moves backwards and across a month boundary", () => {
+    const next = monthDropBounds(event, new Date(2026, 6, 6), new Date(2026, 5, 30));
+    expect(next?.start).toEqual(new Date(2026, 5, 30, 9, 30));
+    expect(next?.end).toEqual(new Date(2026, 5, 30, 10, 15));
+  });
+
+  it("keeps a multi-day event's duration", () => {
+    const trip: CalendarEvent = {
+      title: "Trip",
+      start: new Date(2026, 6, 6, 8),
+      end: new Date(2026, 6, 10, 20),
+    };
+    const next = monthDropBounds(trip, new Date(2026, 6, 8), new Date(2026, 6, 10));
+    expect(next?.start).toEqual(new Date(2026, 6, 8, 8));
+    expect(next?.end).toEqual(new Date(2026, 6, 12, 20));
+  });
+
+  it("returns null when the drop lands on the day it started", () => {
+    expect(monthDropBounds(event, new Date(2026, 6, 6, 1), new Date(2026, 6, 6, 23))).toBeNull();
   });
 });

--- a/packages/core/src/utils/drag.ts
+++ b/packages/core/src/utils/drag.ts
@@ -1,3 +1,4 @@
+import { addDays, differenceInCalendarDays, startOfDay } from "date-fns";
 import type { CalendarEvent, CalendarMode, WeekStartsOn } from "../types";
 import { getViewDays } from "./dates";
 
@@ -85,6 +86,36 @@ export function resolveDraggedBounds(
   // Reject only a shrink past one step — never a move, which preserves duration.
   if (newDuration < snapMinutes * 60_000 && newDuration < oldDuration) return null;
   return { start: nextStart, end: nextEnd };
+}
+
+/**
+ * The all-day range swept out between two day cells of the month grid, ordered
+ * whichever way the sweep ran: `start` is midnight of the first day and `end` is
+ * midnight after the last, so a one-day sweep still yields a usable event. Shared
+ * by both renderers so a month drag-to-create means the same thing on each.
+ */
+export function monthCreateRange(anchor: Date, hover: Date): { start: Date; end: Date } {
+  const a = startOfDay(anchor);
+  const b = startOfDay(hover);
+  const first = a.getTime() <= b.getTime() ? a : b;
+  const last = a.getTime() <= b.getTime() ? b : a;
+  return { start: first, end: addDays(last, 1) };
+}
+
+/**
+ * The new bounds for an event picked up on `fromDay` and dropped on `toDay` in
+ * the month grid: both ends move by the same number of calendar days, so the
+ * event keeps its time of day and duration (DST included). Returns `null` when
+ * the drop lands on the day it started, so a stray drag commits nothing.
+ */
+export function monthDropBounds<T>(
+  event: CalendarEvent<T>,
+  fromDay: Date,
+  toDay: Date,
+): { start: Date; end: Date } | null {
+  const delta = differenceInCalendarDays(startOfDay(toDay), startOfDay(fromDay));
+  if (delta === 0) return null;
+  return { start: addDays(event.start, delta), end: addDays(event.end, delta) };
 }
 
 /**

--- a/packages/dom/src/Calendar.tsx
+++ b/packages/dom/src/Calendar.tsx
@@ -146,13 +146,24 @@ export interface CalendarProps<T = unknown>
   eventOverlap?: boolean;
   /** Snap dragged/created events to this many minutes. */
   dragStepMinutes?: number;
-  /** Tap empty grid space. */
+  /**
+   * Tap empty space: the date+time pressed on the week/day grid, or the tapped
+   * day at midnight in `month` mode (where it fires alongside `onPressDay`).
+   */
   onPressCell?: (date: Date) => void;
-  /** Drag empty grid space to create. */
+  /**
+   * Drag empty space to create. On the week/day grid that sweeps out a time
+   * range; in `month` mode it sweeps out an **all-day** span across the days
+   * dragged (`start` at midnight of the first, `end` at midnight after the last).
+   */
   onCreateEvent?: (start: Date, end: Date) => void;
   /** Fires when an event drag begins. */
   onDragStart?: (event: CalendarEvent<T>) => void;
-  /** Enables drag-to-move/resize; return `false` to reject the drop. */
+  /**
+   * Enables drag-to-move/resize; return `false` to reject the drop. In `month`
+   * mode an event chip can be dragged onto another day, shifting both ends by the
+   * days dragged so the time of day and duration are kept.
+   */
   onDragEvent?: (event: CalendarEvent<T>, start: Date, end: Date) => void | boolean;
   /** Tap a day's column header. */
   onPressDateHeader?: (day: Date) => void;
@@ -173,6 +184,11 @@ export interface CalendarProps<T = unknown>
   moreLabel?: string;
   /** Render neighbouring months' days in the leading/trailing cells (default true). */
   showAdjacentMonths?: boolean;
+  /**
+   * Render the built-in "Month yyyy" title above the month grid. Default true. Set
+   * false when your own header already shows the month and year. Month mode only.
+   */
+  showTitle?: boolean;
   /** Weekday header label width: `narrow` ("M"), `short` ("Mon", default), or `long` ("Monday"). */
   weekdayFormat?: WeekdayFormat;
   /** Fill the cell with the range background instead of the pill band. */
@@ -309,6 +325,7 @@ export function Calendar<T = unknown>({
   maxVisibleEventCount,
   moreLabel,
   showAdjacentMonths,
+  showTitle,
   weekdayFormat,
   fillCellOnSelection,
   selectedRange,
@@ -412,6 +429,7 @@ export function Calendar<T = unknown>({
         maxVisibleEventCount={maxVisibleEventCount}
         moreLabel={moreLabel}
         showAdjacentMonths={showAdjacentMonths}
+        showTitle={showTitle}
         fillCellOnSelection={fillCellOnSelection}
         selectedRange={selectedRange}
         selectedDates={selectedDates}
@@ -420,7 +438,12 @@ export function Calendar<T = unknown>({
         isDateDisabled={isDateDisabled}
         keyboardDayNavigation={keyboardDayNavigation}
         onPressDay={onPressDay}
+        onPressCell={onPressCell}
         onCreateEvent={onCreateEvent}
+        onDragEvent={onDragEvent}
+        onDragStart={onDragStart}
+        eventStartEditable={eventStartEditable}
+        eventOverlap={eventOverlap}
         onPressEvent={onPressEvent}
         onPressMore={onPressMore}
         renderEvent={renderMonthEvent}

--- a/packages/dom/src/MonthView.tsx
+++ b/packages/dom/src/MonthView.tsx
@@ -30,8 +30,11 @@ import {
   isBackgroundEvent,
   isAllDayEvent,
   layoutMonthWeek,
+  monthCreateRange,
+  monthDropBounds,
   type MonthGridDay,
   type MonthGridWeek,
+  overlapsOtherEvents,
   rangeBandKind,
   type WeekdayFormat,
   type WeekStartsOn,
@@ -66,6 +69,8 @@ const DATE_ROW = 24;
 const CHIP_HEIGHT = 18;
 const CHIP_GAP = 2;
 const CELL_PAD = 4;
+// Opacity of an event chip while it is being dragged to another day.
+const DRAGGED_CHIP_OPACITY = 0.4;
 
 /** Props passed to a custom month event chip renderer. */
 export interface DomMonthEventArgs<T = unknown> {
@@ -77,6 +82,13 @@ export interface DomMonthEventArgs<T = unknown> {
 
 /** A component that renders a single month-grid event chip. */
 export type DomMonthEvent<T = unknown> = ComponentType<DomMonthEventArgs<T>>;
+
+// An in-progress month drag: either a day span being swept out for a new event,
+// or an existing event being carried to another day. Days are held as start-of-day
+// timestamps, so the reducer-ish updates compare cheaply.
+type MonthDrag<T> =
+  | { kind: "create"; anchor: number; hover: number }
+  | { kind: "move"; event: CalendarEvent<T>; from: number; to: number };
 
 /** Props for {@link MonthView}. */
 export interface MonthViewProps<T = unknown>
@@ -140,6 +152,11 @@ export interface MonthViewProps<T = unknown>
   /** Fired when a selectable day is clicked. */
   onPressDay?: (date: Date) => void;
   /**
+   * Fired alongside `onPressDay` when a day cell is clicked, with the same day at
+   * midnight, so one handler can create events across month and week/day modes.
+   */
+  onPressCell?: (date: Date) => void;
+  /**
    * In events mode, enables drag-to-create: press on a day and drag across others
    * to sketch a span, then release to fire this with the all-day range (`start` at
    * midnight of the first day, `end` at midnight after the last, exclusive). A plain
@@ -147,6 +164,20 @@ export interface MonthViewProps<T = unknown>
    * carry `data-creating` for styling.
    */
   onCreateEvent?: (start: Date, end: Date) => void;
+  /**
+   * In events mode, enables drag-to-reschedule: press an event chip and drop it on
+   * another day. Called with the event and its new `start`/`end`, both shifted by
+   * the whole days dragged, so the time of day and duration are preserved. Return
+   * `false` to reject the drop. The day under the pointer carries `data-drop` for
+   * styling.
+   */
+  onDragEvent?: (event: CalendarEvent<T>, start: Date, end: Date) => void | boolean;
+  /** Fired the instant an event is picked up for a drag, before anything is committed. */
+  onDragStart?: (event: CalendarEvent<T>) => void;
+  /** Allow moving events by default (per-event `startEditable` overrides). Default true. */
+  eventStartEditable?: boolean;
+  /** Reject a drop that would overlap another event (default true = allowed). */
+  eventOverlap?: boolean;
   /**
    * When events are shown, also make the day cells keyboard-navigable: a single
    * roving tab stop, arrow keys move the focus, Enter opens the day (`onPressDay`).
@@ -268,6 +299,9 @@ function eventCellDefault(
   theme: DomCalendarTheme,
   height: number,
   highlightWeekends: boolean,
+  // True while a drag is over this day: a create sweep covering it, or a move
+  // about to land on it. Tinted over the weekend shading so the drag reads live.
+  isDragTarget: boolean,
 ): SlotDefault {
   return {
     base: {
@@ -286,8 +320,9 @@ function eventCellDefault(
     },
     themed: {
       borderTop: `1px solid ${theme.gridLine}`,
-      background:
-        highlightWeekends && day.isWeekend && !day.isInRange
+      background: isDragTarget
+        ? theme.rangeBackground
+        : highlightWeekends && day.isWeekend && !day.isInRange
           ? theme.weekendBackground
           : "transparent",
       color: day.isDisabled ? theme.textDisabled : theme.text,
@@ -442,7 +477,12 @@ export function MonthView<T = unknown>({
   maxDate,
   isDateDisabled,
   onPressDay,
+  onPressCell,
   onCreateEvent,
+  onDragEvent,
+  onDragStart,
+  eventStartEditable = true,
+  eventOverlap = true,
   keyboardDayNavigation = false,
   className,
   style,
@@ -573,44 +613,87 @@ export function MonthView<T = unknown>({
   const gridRef = useRef<HTMLDivElement>(null);
   const focusKey = format(focusedDate, "yyyy-MM-dd");
 
-  // Drag-to-create (events mode): press a day and drag across others to sketch an
-  // all-day span, released on a window pointerup so a drop anywhere still commits.
-  const [creating, setCreating] = useState<{ anchor: number; hover: number } | null>(null);
-  const creatingRef = useRef(creating);
-  creatingRef.current = creating;
+  // Dragging (events mode): press a day and drag across others to sketch an
+  // all-day span, or press an event chip and drop it on another day. Both are
+  // released on a window pointerup, so letting go anywhere still commits.
+  const [drag, setDrag] = useState<MonthDrag<T> | null>(null);
+  const dragRef = useRef(drag);
+  dragRef.current = drag;
   const movedRef = useRef(false);
-  // Set when a drag commits, so the click the browser fires next is swallowed
-  // (it must not also open the day via onPressDay).
+  // Set when a drag commits, so the click the browser fires next is swallowed (it
+  // must not also open the day, or the event the drag landed on). A drag that ends
+  // over a different element than it began on gets its trailing click on their
+  // common ancestor instead, where no handler consumes the guard — so every press
+  // clears it first, keeping it scoped to the one interaction that set it.
   const suppressClickRef = useRef(false);
+  const consumeSuppressedClick = () => {
+    if (!suppressClickRef.current) return false;
+    suppressClickRef.current = false;
+    return true;
+  };
+  // `disabled` and `draggable: false` lock an event outright; `startEditable`
+  // (per event, falling back to the grid default) allows or blocks a move.
+  const canMove = (event: CalendarEvent<T>) =>
+    onDragEvent != null &&
+    !event.disabled &&
+    event.draggable !== false &&
+    (event.startEditable ?? eventStartEditable);
+  // A fresh press starts a new interaction, so any guard left over from the
+  // previous one is stale.
+  const beginPress = () => {
+    suppressClickRef.current = false;
+    movedRef.current = false;
+  };
   const beginCreate = (day: Date) => {
     if (!onCreateEvent) return;
     const t = startOfDay(day).getTime();
-    movedRef.current = false;
-    setCreating({ anchor: t, hover: t });
+    setDrag({ kind: "create", anchor: t, hover: t });
   };
-  const extendCreate = (day: Date) => {
-    if (!creatingRef.current) return;
+  const beginMove = (event: CalendarEvent<T>, day: Date) => {
+    if (!canMove(event)) return;
     const t = startOfDay(day).getTime();
-    if (t !== creatingRef.current.hover) {
-      movedRef.current = true;
-      setCreating((c) => (c ? { ...c, hover: t } : c));
-    }
+    setDrag({ kind: "move", event, from: t, to: t });
+    onDragStart?.(event);
   };
-  const isCreating = creating !== null;
+  const extendDrag = (day: Date) => {
+    const current = dragRef.current;
+    if (!current) return;
+    const t = startOfDay(day).getTime();
+    if (t === (current.kind === "create" ? current.hover : current.to)) return;
+    movedRef.current = true;
+    setDrag(current.kind === "create" ? { ...current, hover: t } : { ...current, to: t });
+  };
+  const isDragging = drag !== null;
+  // Whether any month drag is wired up at all, so the cells only take over touch
+  // scrolling and pointer tracking when one of the handlers can actually fire.
+  const dragWired = onCreateEvent != null || onDragEvent != null;
   useEffect(() => {
-    if (!isCreating) return;
+    if (!isDragging) return;
     const finish = () => {
-      const c = creatingRef.current;
-      setCreating(null);
-      if (!c || !movedRef.current) return;
+      const current = dragRef.current;
+      setDrag(null);
+      if (!current || !movedRef.current) return;
       suppressClickRef.current = true;
-      const lo = Math.min(c.anchor, c.hover);
-      const hi = Math.max(c.anchor, c.hover);
-      onCreateEvent?.(new Date(lo), addDays(new Date(hi), 1));
+      if (current.kind === "create") {
+        const range = monthCreateRange(new Date(current.anchor), new Date(current.hover));
+        onCreateEvent?.(range.start, range.end);
+        return;
+      }
+      const next = monthDropBounds(current.event, new Date(current.from), new Date(current.to));
+      if (!next) return;
+      // Reject a drop that would land the event on top of another when
+      // `eventOverlap` is off, before the consumer's handler ever sees it.
+      if (
+        eventOverlap === false &&
+        overlapsOtherEvents(events ?? [], current.event, next.start, next.end)
+      ) {
+        return;
+      }
+      onDragEvent?.(current.event, next.start, next.end);
     };
     window.addEventListener("pointerup", finish);
     return () => window.removeEventListener("pointerup", finish);
-  }, [isCreating, onCreateEvent]);
+  }, [isDragging, onCreateEvent, onDragEvent, eventOverlap, events]);
   const onKeyDown = (e: ReactKeyboardEvent<HTMLDivElement>) => {
     let next: Date | null = null;
     if (e.key === "ArrowLeft") next = addDays(focusedDate, -1);
@@ -740,9 +823,12 @@ export function MonthView<T = unknown>({
                 );
                 const dayTime = startOfDay(day.date).getTime();
                 const inCreate =
-                  creating != null &&
-                  dayTime >= Math.min(creating.anchor, creating.hover) &&
-                  dayTime <= Math.max(creating.anchor, creating.hover);
+                  drag?.kind === "create" &&
+                  dayTime >= Math.min(drag.anchor, drag.hover) &&
+                  dayTime <= Math.max(drag.anchor, drag.hover);
+                // The day an event is about to land on (not the one it came from).
+                const isDropTarget =
+                  drag?.kind === "move" && dayTime === drag.to && drag.to !== drag.from;
                 // Present/absent data-* attributes so consumers can style day state
                 // with CSS/Tailwind variants (e.g. `data-[today]:bg-blue-500`).
                 const dayData = dataState({
@@ -753,6 +839,7 @@ export function MonthView<T = unknown>({
                   "data-outside": !day.isCurrentMonth,
                   "data-disabled": day.isDisabled,
                   "data-creating": inCreate,
+                  "data-drop": isDropTarget,
                 });
 
                 if (eventsMode) {
@@ -768,7 +855,13 @@ export function MonthView<T = unknown>({
                   const dayLabel = format(day.date, "d MMMM", locale ? { locale } : undefined);
                   const dayCellProps = slot(
                     "day",
-                    eventCellDefault(day, theme, cellHeight, highlightWeekends),
+                    eventCellDefault(
+                      day,
+                      theme,
+                      cellHeight,
+                      highlightWeekends,
+                      inCreate || isDropTarget,
+                    ),
                   );
                   return (
                     // Events mode: by default the cell is not a tab stop, so keyboard
@@ -785,30 +878,32 @@ export function MonthView<T = unknown>({
                       aria-disabled={day.isDisabled || undefined}
                       aria-label={label}
                       {...dayCellProps}
-                      // Drag-to-create disables touch scroll on the cell so a swipe
-                      // sketches a span instead of scrolling the grid.
+                      // Dragging disables touch scroll on the cell so a swipe
+                      // sketches a span (or carries an event) instead of scrolling
+                      // the grid, and stops the sweep from text-selecting the day
+                      // numbers and chip titles it passes over.
                       style={
-                        onCreateEvent
-                          ? { ...dayCellProps.style, touchAction: "none" }
+                        dragWired
+                          ? { ...dayCellProps.style, touchAction: "none", userSelect: "none" }
                           : dayCellProps.style
                       }
                       onPointerDown={
-                        onCreateEvent && !day.isDisabled
+                        dragWired && !day.isDisabled
                           ? (e) => {
-                              if (e.button === 0) beginCreate(day.date);
+                              if (e.button !== 0) return;
+                              beginPress();
+                              beginCreate(day.date);
                             }
                           : undefined
                       }
-                      onPointerEnter={onCreateEvent ? () => extendCreate(day.date) : undefined}
+                      onPointerEnter={dragWired ? () => extendDrag(day.date) : undefined}
                       onClick={
                         day.isDisabled
                           ? undefined
                           : () => {
-                              if (suppressClickRef.current) {
-                                suppressClickRef.current = false;
-                                return;
-                              }
+                              if (consumeSuppressedClick()) return;
                               onPressDay?.(day.date);
+                              onPressCell?.(startOfDay(day.date));
                             }
                       }
                       onKeyDown={
@@ -819,6 +914,7 @@ export function MonthView<T = unknown>({
                               if (e.key === "Enter" || e.key === " ") {
                                 e.preventDefault();
                                 onPressDay?.(day.date);
+                                onPressCell?.(startOfDay(day.date));
                               }
                             }
                           : undefined
@@ -832,18 +928,30 @@ export function MonthView<T = unknown>({
                           overflowing right across the days they span. Rendered here
                           (not a row overlay) so each bar is valid content of its
                           start day's gridcell and reads with that day. Made
-                          non-interactive mid drag-create so a sweep reaches the
+                          non-interactive mid drag so a sweep (or a move) reaches the
                           cells beneath. */}
                       {barSegs
                         .filter((b) => b.startCol === dayCol)
                         .map((b) => {
                           const span = b.endCol - b.startCol + 1;
+                          const isDragged = drag?.kind === "move" && drag.event === b.seg.event;
                           return (
                             <button
                               key={`bar-${b.seg.event.start.toISOString()}:${b.seg.event.title}:${b.seg.lane}`}
                               type="button"
+                              onPointerDown={
+                                canMove(b.seg.event)
+                                  ? (e) => {
+                                      if (e.button !== 0) return;
+                                      e.stopPropagation();
+                                      beginPress();
+                                      beginMove(b.seg.event, day.date);
+                                    }
+                                  : undefined
+                              }
                               onClick={(e) => {
                                 e.stopPropagation();
+                                if (consumeSuppressedClick()) return;
                                 onPressEvent?.(b.seg.event);
                               }}
                               {...barChipButton}
@@ -868,7 +976,12 @@ export function MonthView<T = unknown>({
                                   CHIP_GAP +
                                   b.seg.lane * (CHIP_HEIGHT + CHIP_GAP),
                                 height: CHIP_HEIGHT,
-                                pointerEvents: isCreating ? "none" : "auto",
+                                pointerEvents: isDragging ? "none" : "auto",
+                                // Fade the bar being carried, so the tinted drop
+                                // target reads as where it is going.
+                                opacity: isDragged ? DRAGGED_CHIP_OPACITY : undefined,
+                                cursor: canMove(b.seg.event) ? "grab" : undefined,
+                                touchAction: dragWired ? "none" : undefined,
                                 zIndex: 2,
                               }}
                             >
@@ -1024,7 +1137,14 @@ export function MonthView<T = unknown>({
                     aria-label={label}
                     aria-pressed={day.isSelected || day.isInRange}
                     {...slot("day", dayCellDefault(day, theme, highlightWeekends))}
-                    onClick={day.isDisabled ? undefined : () => onPressDay?.(day.date)}
+                    onClick={
+                      day.isDisabled
+                        ? undefined
+                        : () => {
+                            onPressDay?.(day.date);
+                            onPressCell?.(startOfDay(day.date));
+                          }
+                    }
                     onMouseEnter={day.isDisabled ? undefined : () => setHoveredKey(day.id)}
                     onMouseLeave={() => setHoveredKey((k) => (k === day.id ? null : k))}
                   >

--- a/packages/dom/src/__tests__/Calendar.test.tsx
+++ b/packages/dom/src/__tests__/Calendar.test.tsx
@@ -29,6 +29,14 @@ describe("dom Calendar", () => {
     expect(queryByText("09:00 - 11:00")).toBeNull(); // no time-grid label in month mode
   });
 
+  it("hides the month title with showTitle={false}, so an app header can own the label", () => {
+    const { queryByText, getByText } = render(
+      <Calendar mode="month" date={date} events={events} weekStartsOn={1} showTitle={false} />,
+    );
+    expect(queryByText("July 2026")).toBeNull();
+    expect(getByText("Standup")).toBeTruthy(); // the grid itself still renders
+  });
+
   it("renders a time grid in week mode", () => {
     const { getByText } = render(
       <Calendar mode="week" date={date} events={events} weekStartsOn={1} hourHeight={48} />,

--- a/packages/dom/src/__tests__/MonthView.test.tsx
+++ b/packages/dom/src/__tests__/MonthView.test.tsx
@@ -367,8 +367,12 @@ describe("dom MonthView", () => {
       );
       fireEvent.pointerDown(dayCell(container, "2026-07-06"), { button: 0 });
       fireEvent.pointerEnter(dayCell(container, "2026-07-08"));
-      // Days across the sketched span are flagged for styling.
-      expect(dayCell(container, "2026-07-07").hasAttribute("data-creating")).toBe(true);
+      // Days across the sketched span are flagged for styling, and tinted so the
+      // sweep reads live; the day just outside it is neither.
+      const swept = dayCell(container, "2026-07-07");
+      expect(swept.hasAttribute("data-creating")).toBe(true);
+      expect(swept.style.background).toBe("rgb(220, 231, 255)"); // theme.rangeBackground
+      expect(dayCell(container, "2026-07-09").hasAttribute("data-creating")).toBe(false);
       fireEvent.pointerUp(window);
 
       expect(onCreateEvent).toHaveBeenCalledTimes(1);
@@ -417,6 +421,183 @@ describe("dom MonthView", () => {
       fireEvent.click(cell);
       expect(onCreateEvent).not.toHaveBeenCalled();
       expect(onPressDay).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("drag to reschedule", () => {
+    const dayCell = (c: HTMLElement, id: string) =>
+      c.querySelector(`[data-day="${id}"]`) as HTMLElement;
+    const standup: CalendarEvent = {
+      title: "Standup",
+      start: new Date(2026, 6, 6, 9, 30),
+      end: new Date(2026, 6, 6, 10, 15),
+    };
+
+    it("fires onDragEvent with both ends shifted by the days dragged", () => {
+      const onDragEvent = jest.fn();
+      const { container, getByTitle } = render(
+        <MonthView
+          date={new Date(2026, 6, 1)}
+          weekStartsOn={1}
+          events={[standup]}
+          onDragEvent={onDragEvent}
+        />,
+      );
+      const chip = getByTitle("Standup");
+      fireEvent.pointerDown(chip, { button: 0 });
+      fireEvent.pointerEnter(dayCell(container, "2026-07-09"));
+      // The day the event would land on is flagged and tinted; the one it came
+      // from is not. The carried chip fades and stops taking pointer events, so
+      // the drag reaches the cells underneath.
+      const target = dayCell(container, "2026-07-09");
+      expect(target.hasAttribute("data-drop")).toBe(true);
+      expect(target.style.background).toBe("rgb(220, 231, 255)"); // theme.rangeBackground
+      expect(dayCell(container, "2026-07-06").hasAttribute("data-drop")).toBe(false);
+      expect(Number(chip.style.opacity)).toBeLessThan(1);
+      expect(chip.style.pointerEvents).toBe("none");
+      fireEvent.pointerUp(window);
+
+      expect(onDragEvent).toHaveBeenCalledTimes(1);
+      const [event, start, end] = onDragEvent.mock.calls[0] as [CalendarEvent, Date, Date];
+      expect(event).toBe(standup);
+      // The time of day and the 45-minute duration survive the move.
+      expect(start).toEqual(new Date(2026, 6, 9, 9, 30));
+      expect(end).toEqual(new Date(2026, 6, 9, 10, 15));
+    });
+
+    it("swallows the click after a drop, so the event is not also opened", () => {
+      const onDragEvent = jest.fn();
+      const onPressEvent = jest.fn();
+      const { container, getByTitle } = render(
+        <MonthView
+          date={new Date(2026, 6, 1)}
+          weekStartsOn={1}
+          events={[standup]}
+          onDragEvent={onDragEvent}
+          onPressEvent={onPressEvent}
+        />,
+      );
+      const chip = getByTitle("Standup");
+      fireEvent.pointerDown(chip, { button: 0 });
+      fireEvent.pointerEnter(dayCell(container, "2026-07-09"));
+      fireEvent.pointerUp(window);
+      fireEvent.click(chip);
+      expect(onDragEvent).toHaveBeenCalledTimes(1);
+      expect(onPressEvent).not.toHaveBeenCalled();
+    });
+
+    it("leaves a plain click on the chip to onPressEvent", () => {
+      const onDragEvent = jest.fn();
+      const onPressEvent = jest.fn();
+      const { getByTitle } = render(
+        <MonthView
+          date={new Date(2026, 6, 1)}
+          weekStartsOn={1}
+          events={[standup]}
+          onDragEvent={onDragEvent}
+          onPressEvent={onPressEvent}
+        />,
+      );
+      const chip = getByTitle("Standup");
+      fireEvent.pointerDown(chip, { button: 0 });
+      fireEvent.pointerUp(window);
+      fireEvent.click(chip);
+      expect(onDragEvent).not.toHaveBeenCalled();
+      expect(onPressEvent).toHaveBeenCalledTimes(1);
+    });
+
+    it("does not pick up an event locked with draggable: false", () => {
+      const onDragEvent = jest.fn();
+      const locked: CalendarEvent = { ...standup, draggable: false };
+      const { container, getByTitle } = render(
+        <MonthView
+          date={new Date(2026, 6, 1)}
+          weekStartsOn={1}
+          events={[locked]}
+          onDragEvent={onDragEvent}
+        />,
+      );
+      fireEvent.pointerDown(getByTitle("Standup"), { button: 0 });
+      fireEvent.pointerEnter(dayCell(container, "2026-07-09"));
+      fireEvent.pointerUp(window);
+      expect(onDragEvent).not.toHaveBeenCalled();
+    });
+
+    it("honours eventStartEditable={false} as the grid-wide lock", () => {
+      const onDragEvent = jest.fn();
+      const { container, getByTitle } = render(
+        <MonthView
+          date={new Date(2026, 6, 1)}
+          weekStartsOn={1}
+          events={[standup]}
+          eventStartEditable={false}
+          onDragEvent={onDragEvent}
+        />,
+      );
+      fireEvent.pointerDown(getByTitle("Standup"), { button: 0 });
+      fireEvent.pointerEnter(dayCell(container, "2026-07-09"));
+      fireEvent.pointerUp(window);
+      expect(onDragEvent).not.toHaveBeenCalled();
+    });
+
+    it("rejects a drop onto an overlapping event when eventOverlap is false", () => {
+      const onDragEvent = jest.fn();
+      // Same wall-clock slot on the 9th, so the move would collide there.
+      const clash: CalendarEvent = {
+        title: "Clash",
+        start: new Date(2026, 6, 9, 9, 30),
+        end: new Date(2026, 6, 9, 10, 15),
+      };
+      const { container, getByTitle } = render(
+        <MonthView
+          date={new Date(2026, 6, 1)}
+          weekStartsOn={1}
+          events={[standup, clash]}
+          eventOverlap={false}
+          onDragEvent={onDragEvent}
+        />,
+      );
+      fireEvent.pointerDown(getByTitle("Standup"), { button: 0 });
+      fireEvent.pointerEnter(dayCell(container, "2026-07-09"));
+      fireEvent.pointerUp(window);
+      expect(onDragEvent).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("onPressCell", () => {
+    const dayCell = (c: HTMLElement, id: string) =>
+      c.querySelector(`[data-day="${id}"]`) as HTMLElement;
+
+    it("fires with the tapped day at midnight, alongside onPressDay", () => {
+      const onPressCell = jest.fn();
+      const onPressDay = jest.fn();
+      const { container } = render(
+        <MonthView
+          date={new Date(2026, 6, 1)}
+          weekStartsOn={1}
+          events={[]}
+          onPressCell={onPressCell}
+          onPressDay={onPressDay}
+        />,
+      );
+      fireEvent.click(dayCell(container, "2026-07-06"));
+      expect(onPressCell).toHaveBeenCalledWith(new Date(2026, 6, 6));
+      expect(onPressDay).toHaveBeenCalledTimes(1);
+    });
+
+    it("does not fire for a disabled day", () => {
+      const onPressCell = jest.fn();
+      const { container } = render(
+        <MonthView
+          date={new Date(2026, 6, 1)}
+          weekStartsOn={1}
+          events={[]}
+          isDateDisabled={(d) => d.getDate() === 6}
+          onPressCell={onPressCell}
+        />,
+      );
+      fireEvent.click(dayCell(container, "2026-07-06"));
+      expect(onPressCell).not.toHaveBeenCalled();
     });
   });
 });

--- a/packages/native/src/components/Calendar.tsx
+++ b/packages/native/src/components/Calendar.tsx
@@ -67,19 +67,20 @@ export type CalendarProps<T> = SlotStyleProps<CalendarSlot> & {
   /** Long-press an event (month/week/day). */
   onLongPressEvent?: (event: CalendarEvent<T>) => void;
   /**
-   * Enable drag-to-move and drag-to-resize on the week/day grid. Called with the
-   * dragged event and its new start/end (snapped to `dragStepMinutes`); update
-   * your own event state in response. Long-press an event to move it (drag
-   * horizontally to change the day too); drag its bottom grip to resize. Return
-   * `false` to reject the drop (e.g. an overlap) and snap the event back.
+   * Enable drag-to-move and drag-to-resize. Called with the dragged event and its
+   * new start/end; update your own event state in response. On the week/day grid,
+   * long-press an event to move it (drag horizontally to change the day too) or
+   * drag its bottom grip to resize, snapped to `dragStepMinutes`. In `month` mode,
+   * long-press an event bar and drop it on another day: both ends shift by the
+   * days dragged, so the time of day and duration are kept. Return `false` to
+   * reject the drop (e.g. an overlap) and snap the event back.
    */
   onDragEvent?: EventDragHandler<T>;
   /**
-   * Fired when a move or resize gesture begins on the week/day grid, before any
-   * change is committed: on grab for a move (after the long-press), and when a
-   * resize drag starts. Use it to trigger haptic feedback, e.g.
-   * `Haptics.impactAsync()` from `expo-haptics`. Native-only and inert unless
-   * `onDragEvent` is also set.
+   * Fired when a drag gesture begins, before any change is committed: on grab for
+   * a move (after the long-press), and when a week/day resize drag starts. Use it
+   * to trigger haptic feedback, e.g. `Haptics.impactAsync()` from `expo-haptics`.
+   * Native-only and inert unless `onDragEvent` is also set.
    */
   onDragStart?: EventDragStartHandler<T>;
   /** Minutes a drag-to-move/resize snaps to. Default 15. */
@@ -97,18 +98,23 @@ export type CalendarProps<T> = SlotStyleProps<CalendarSlot> & {
   onLongPressDay?: (date: Date) => void;
   /** Tap the "+N more" overflow label in a month cell. */
   onPressMore?: (events: CalendarEvent<T>[], date: Date) => void;
-  /** Tap empty space on the week/day grid; receives the date+time pressed. */
+  /**
+   * Tap empty space; receives the date+time pressed on the week/day grid, or the
+   * tapped day at midnight in `month` mode (where it fires alongside `onPressDay`).
+   */
   onPressCell?: (date: Date) => void;
   /** After an empty-cell press, snap the pager back to the active page. Default false. */
   resetPageOnPressCell?: boolean;
   /** Long-press empty space on the week/day grid; receives the date+time. */
   onLongPressCell?: (date: Date) => void;
   /**
-   * Enable drag-to-create on the week/day grid: long-press empty space and drag
-   * to sweep out a new event's time range. Called on release with the snapped
-   * `start`/`end` (to `dragStepMinutes`); create your own event in response. A
-   * stationary press yields a one-step range. Native-only; supersedes
-   * `onLongPressCell` on empty space when set.
+   * Enable drag-to-create: long-press empty space and drag to sweep out a new
+   * event, then release. On the week/day grid that is a time range snapped to
+   * `dragStepMinutes` (a stationary press yields a one-step range); in `month`
+   * mode it is an **all-day** span across the days swept — `start` at midnight of
+   * the first day, `end` at midnight after the last. Create your own event in
+   * response. Supersedes `onLongPressCell` (and, in month mode, `onLongPressDay`)
+   * on empty space when set.
    */
   onCreateEvent?: (start: Date, end: Date) => void;
   /** Tap a day's column header on the week/day grid (default header only). */
@@ -209,6 +215,11 @@ export type CalendarProps<T> = SlotStyleProps<CalendarSlot> & {
   hourComponent?: HourRenderer;
   /** Always render six week rows in month view, for a fixed-height grid. Default false. */
   showSixWeeks?: boolean;
+  /**
+   * Render the built-in "MMMM yyyy" title above the month grid. Default true. Set
+   * false when your own header already shows the month and year. Month mode only.
+   */
+  showTitle?: boolean;
   /** Allow swiping between pages (all modes). Default true. */
   swipeEnabled?: boolean;
   /** Show the vertical scroll indicator on the week/day grid. Default true. */
@@ -416,6 +427,7 @@ export function Calendar<T>({
   weekNumberPrefix,
   hourComponent,
   showSixWeeks,
+  showTitle,
   swipeEnabled,
   showVerticalScrollIndicator,
   verticalScrollEnabled,
@@ -557,6 +569,7 @@ export function Calendar<T>({
           disableMonthEventCellPress={disableMonthEventCellPress}
           isRTL={isRTL}
           showSixWeeks={showSixWeeks}
+          showTitle={showTitle}
           activeDate={activeDate}
           renderHeaderForMonthView={renderHeaderForMonthView}
           renderCustomDateForMonth={renderCustomDateForMonth}
@@ -565,9 +578,15 @@ export function Calendar<T>({
           keyExtractor={keyExtractor}
           onPressDay={onPressDay}
           onLongPressDay={onLongPressDay}
+          onPressCell={onPressCell}
           onPressEvent={handlePressEvent}
           onLongPressEvent={handleLongPressEvent}
           onPressMore={onPressMore}
+          onCreateEvent={onCreateEvent}
+          onDragEvent={onDragEvent}
+          onDragStart={onDragStart}
+          eventStartEditable={eventStartEditable}
+          eventOverlap={eventOverlap}
           onChangeDate={handleChangeDate}
           freeSwipe={freeSwipe}
           swipeEnabled={swipeEnabled}

--- a/packages/native/src/components/MonthPager.tsx
+++ b/packages/native/src/components/MonthPager.tsx
@@ -17,7 +17,14 @@ import {
   type ViewStyle,
 } from "react-native";
 import { useCalendarTheme } from "../theme";
-import type { CalendarEvent, EventKeyExtractor, RenderEvent, WeekStartsOn } from "../types";
+import type {
+  CalendarEvent,
+  EventDragHandler,
+  EventDragStartHandler,
+  EventKeyExtractor,
+  RenderEvent,
+  WeekStartsOn,
+} from "../types";
 import {
   type WeekdayFormat,
   filterHiddenDays,
@@ -62,13 +69,27 @@ export type MonthPagerProps<T> = {
   keyExtractor: EventKeyExtractor<T>;
   onPressDay?: (date: Date) => void;
   onLongPressDay?: (date: Date) => void;
+  /** Tap an empty day cell; receives the day at midnight. */
+  onPressCell?: (date: Date) => void;
   onPressEvent: (event: CalendarEvent<T>) => void;
   onLongPressEvent?: (event: CalendarEvent<T>) => void;
   onPressMore?: (events: CalendarEvent<T>[], date: Date) => void;
+  /** Drag across empty day cells to sweep out an all-day span for a new event. */
+  onCreateEvent?: (start: Date, end: Date) => void;
+  /** Drag an event bar onto another day to reschedule it. */
+  onDragEvent?: EventDragHandler<T>;
+  /** Fired when a month drag picks an event up, before anything is committed. */
+  onDragStart?: EventDragStartHandler<T>;
+  /** Allow moving events by default (per-event `startEditable` overrides). Default true. */
+  eventStartEditable?: boolean;
+  /** Reject a drop that would overlap another event (default true = allowed). */
+  eventOverlap?: boolean;
   onChangeDate: (date: Date) => void;
   freeSwipe?: boolean;
   swipeEnabled?: boolean;
   showSixWeeks?: boolean;
+  /** Render the "MMMM yyyy" title above the weekday header. Default true. */
+  showTitle?: boolean;
   activeDate?: Date;
   /** Replace the weekday-label header above the month grid. Receives the week's days. */
   renderHeaderForMonthView?: (weekDays: Date[]) => React.ReactNode;
@@ -95,13 +116,20 @@ function MonthPagerInner<T>({
   keyExtractor,
   onPressDay,
   onLongPressDay,
+  onPressCell,
   onPressEvent,
   onLongPressEvent,
   onPressMore,
+  onCreateEvent,
+  onDragEvent,
+  onDragStart,
+  eventStartEditable,
+  eventOverlap,
   onChangeDate,
   freeSwipe = false,
   swipeEnabled = true,
   showSixWeeks = false,
+  showTitle = true,
   activeDate,
   renderHeaderForMonthView,
   renderCustomDateForMonth,
@@ -263,9 +291,15 @@ function MonthPagerInner<T>({
           keyExtractor={keyExtractor}
           onPressDay={onPressDay}
           onLongPressDay={onLongPressDay}
+          onPressCell={onPressCell}
           onPressEvent={onPressEvent}
           onLongPressEvent={onLongPressEvent}
           onPressMore={onPressMore}
+          onCreateEvent={onCreateEvent}
+          onDragEvent={onDragEvent}
+          onDragStart={onDragStart}
+          eventStartEditable={eventStartEditable}
+          eventOverlap={eventOverlap}
           renderCustomDateForMonth={renderCustomDateForMonth}
           classNames={classNames}
           styles={styleOverrides}
@@ -278,10 +312,12 @@ function MonthPagerInner<T>({
       events,
       maxVisibleEventCount,
       weekStartsOn,
+      hiddenDays,
       locale,
       sortedMonthView,
       moreLabel,
       showAdjacentMonths,
+      highlightWeekends,
       disableMonthEventCellPress,
       isRTL,
       showSixWeeks,
@@ -291,9 +327,15 @@ function MonthPagerInner<T>({
       keyExtractor,
       onPressDay,
       onLongPressDay,
+      onPressCell,
       onPressEvent,
       onLongPressEvent,
       onPressMore,
+      onCreateEvent,
+      onDragEvent,
+      onDragStart,
+      eventStartEditable,
+      eventOverlap,
       renderCustomDateForMonth,
       classNames,
       styleOverrides,
@@ -304,15 +346,17 @@ function MonthPagerInner<T>({
     <View ref={containerRef} style={[styles.container, theme.containers.monthContainer]}>
       {/* The active month's title, above the (shared) weekday header — mirrors the
           dom MonthView's title. The grids below omit their own title/weekdays. */}
-      <Text
-        {...slot<TextStyle>("title", {
-          base: styles.monthTitle,
-          themed: [theme.text.monthTitle, { color: theme.colors.text }],
-        })}
-        allowFontScaling={false}
-      >
-        {format(date, "MMMM yyyy", locale ? { locale } : undefined)}
-      </Text>
+      {showTitle ? (
+        <Text
+          {...slot<TextStyle>("title", {
+            base: styles.monthTitle,
+            themed: [theme.text.monthTitle, { color: theme.colors.text }],
+          })}
+          allowFontScaling={false}
+        >
+          {format(date, "MMMM yyyy", locale ? { locale } : undefined)}
+        </Text>
+      ) : null}
       {renderHeaderForMonthView ? (
         renderHeaderForMonthView(weekDays)
       ) : (

--- a/packages/native/src/components/MonthView.tsx
+++ b/packages/native/src/components/MonthView.tsx
@@ -1,10 +1,11 @@
 import { format, type Locale, isSameMonth, startOfDay } from "date-fns";
-import { memo, type ReactElement, useMemo, useState } from "react";
+import { memo, type ReactElement, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
   type DimensionValue,
   type LayoutChangeEvent,
   Modal,
   Platform,
+  type PointerEvent as RNPointerEvent,
   Pressable,
   ScrollView,
   StyleSheet,
@@ -15,12 +16,20 @@ import {
   View,
   type ViewStyle,
 } from "react-native";
+import { Gesture, GestureDetector } from "react-native-gesture-handler";
 
 // Web drag-to-select relays cell pointer events up to MonthList; native drag is
 // driven by a list-level pan there instead.
 const isWeb = Platform.OS === "web";
 import { useCalendarTheme } from "../theme";
-import type { CalendarEvent, EventKeyExtractor, RenderEvent, WeekStartsOn } from "../types";
+import type {
+  CalendarEvent,
+  EventDragHandler,
+  EventDragStartHandler,
+  EventKeyExtractor,
+  RenderEvent,
+  WeekStartsOn,
+} from "../types";
 import { createSlots, type SlotStyleProps } from "../utils/slots";
 import { withEventAccessibilityLabel } from "../utils/withEventAccessibilityLabel";
 import {
@@ -28,6 +37,7 @@ import {
   type EventAccessibilityLabeler,
   type WeekdayFormat,
   daySelectionState,
+  isDateSelectable,
   useCalendarSelection,
   weekdayFormatToken,
 } from "@super-calendar/core";
@@ -42,6 +52,7 @@ import {
 } from "@super-calendar/core";
 import { monthEventCapacity, monthVisibleCount } from "@super-calendar/core";
 import { layoutMonthWeek, type MonthWeekEvents } from "@super-calendar/core";
+import { monthCreateRange, monthDropBounds, overlapsOtherEvents } from "@super-calendar/core";
 import {
   compareDayEvents,
   groupEventsByDay,
@@ -65,6 +76,12 @@ const EMPTY_LAYOUT = { segments: [], laneCount: 0 } as const;
 const CHIP_INSET_H = 4;
 // Pre-measure fallback so the first paint isn't empty or overflowing.
 const FALLBACK_VISIBLE_COUNT = 3;
+// Hold this long to start a month drag. Shorter than TouchableOpacity's own
+// 500ms long-press so the pan wins the race and the cell's `onLongPressDay`
+// doesn't also fire.
+const DRAG_LONG_PRESS_MS = 400;
+// Opacity of an event bar while it is being dragged to another day.
+const DRAGGED_BAR_OPACITY = 0.4;
 
 const numericStyle = (value: number | string | undefined, fallback: number) =>
   typeof value === "number" ? value : fallback;
@@ -91,6 +108,21 @@ function collectRowEvents<T>(
 }
 
 const pct = (n: number): DimensionValue => `${n}%` as DimensionValue;
+
+// An in-progress month drag: either a day span being swept out for a new event,
+// or an existing event being carried to another day.
+type MonthDrag<T> =
+  | { kind: "create"; anchor: Date; hover: Date }
+  | { kind: "move"; event: CalendarEvent<T>; from: Date; to: Date };
+
+// True when `day` falls inside the span swept out so far (either direction).
+function isInCreateSpan<T>(drag: MonthDrag<T> | null, day: Date): boolean {
+  if (drag?.kind !== "create") return false;
+  const time = startOfDay(day).getTime();
+  const a = startOfDay(drag.anchor).getTime();
+  const b = startOfDay(drag.hover).getTime();
+  return time >= Math.min(a, b) && time <= Math.max(a, b);
+}
 
 /**
  * The styleable parts of {@link MonthView}. Mirrors the dom renderer's slot
@@ -182,9 +214,39 @@ export type MonthViewProps<T> = SlotStyleProps<MonthViewSlot> & {
   keyExtractor: EventKeyExtractor<T>;
   onPressDay?: (date: Date) => void;
   onLongPressDay?: (date: Date) => void;
+  /**
+   * Tap an empty day cell. Fires alongside `onPressDay` with the same day at
+   * midnight, so one handler can create events across month and week/day modes.
+   */
+  onPressCell?: (date: Date) => void;
   onPressEvent: (event: CalendarEvent<T>) => void;
   onLongPressEvent?: (event: CalendarEvent<T>) => void;
   onPressMore?: (events: CalendarEvent<T>[], date: Date) => void;
+  /**
+   * Enable drag-to-create: **long-press an empty day** and sweep across others
+   * (**press and drag** on the web), then release to fire this with the **all-day**
+   * range — `start` at midnight of the first day, `end` at midnight after the last
+   * (exclusive). A sweep that never leaves its day still yields that one day. A
+   * plain tap fires `onPressDay`/`onPressCell` instead.
+   */
+  onCreateEvent?: (start: Date, end: Date) => void;
+  /**
+   * Enable drag-to-reschedule: **long-press an event bar** and drag it onto
+   * another day (**press and drag** on the web). Called on release with the event
+   * and its new `start`/`end`, both shifted by the whole days dragged, so the time
+   * of day and duration are preserved. Return `false` to reject the drop. Update
+   * your own event state in response.
+   */
+  onDragEvent?: EventDragHandler<T>;
+  /**
+   * Fired the instant an event is picked up for a month drag, before anything is
+   * committed. Use it for haptic feedback. Inert unless `onDragEvent` is also set.
+   */
+  onDragStart?: EventDragStartHandler<T>;
+  /** Allow moving events by default (per-event `startEditable` overrides). Default true. */
+  eventStartEditable?: boolean;
+  /** Reject a drop that would overlap another event (default true = allowed). */
+  eventOverlap?: boolean;
   /**
    * Replace the default date badge in each day cell. Receives the day; return
    * your own date label. Event chips and the "+N more" label still render below.
@@ -222,9 +284,15 @@ function MonthViewInner<T>({
   keyExtractor,
   onPressDay,
   onLongPressDay,
+  onPressCell,
   onPressEvent,
   onLongPressEvent,
   onPressMore,
+  onCreateEvent,
+  onDragEvent,
+  onDragStart,
+  eventStartEditable = true,
+  eventOverlap = true,
   renderCustomDateForMonth,
   onDayPointerDown,
   onDayPointerEnter,
@@ -246,8 +314,10 @@ function MonthViewInner<T>({
     () => withEventAccessibilityLabel(renderEvent, eventAccessibilityLabel, false),
     [renderEvent, eventAccessibilityLabel],
   );
-  // Measured grid height, used to auto-fit the event chips per cell.
-  const [gridHeight, setGridHeight] = useState(0);
+  // Measured grid box: the height auto-fits the event chips per cell, and both
+  // dimensions map a drag's position onto a day cell.
+  const [gridSize, setGridSize] = useState({ width: 0, height: 0 });
+  const gridHeight = gridSize.height;
   // Web-only hover highlight on the day badge (mouse pointers); stays null on
   // touch/native, so it never re-renders there. Mirrors the dom renderer.
   const [hoveredKey, setHoveredKey] = useState<string | null>(null);
@@ -326,6 +396,192 @@ function MonthViewInner<T>({
     [showGrid, weeks, eventsByDay],
   );
 
+  // ---- drag to create a day span / reschedule an event ----------------------
+  const dragEnabled = onCreateEvent != null || onDragEvent != null;
+  const gridRef = useRef<View>(null);
+  // The live drag drives the preview; the ref is what the gesture and the web
+  // pointer listeners read, so neither has to be rebuilt as the hover day moves
+  // (rebuilding the gesture mid-drag would cancel it).
+  const [drag, setDrag] = useState<MonthDrag<T> | null>(null);
+  const dragRef = useRef<MonthDrag<T> | null>(null);
+  // Whether the pointer has reached a different day than it started on. The web
+  // has no long-press to disambiguate, so a create only commits once it moves.
+  const movedRef = useRef(false);
+  // Web only: a committed drag has to swallow the click the browser fires next,
+  // so a reschedule doesn't also open the day (or the event) it landed on.
+  const suppressPressRef = useRef(false);
+
+  const applyDrag = useCallback((next: MonthDrag<T> | null) => {
+    dragRef.current = next;
+    setDrag(next);
+  }, []);
+
+  // True when this press is the click trailing a just-committed web drag, which
+  // the caller should swallow. Clears the flag so only that one press is eaten.
+  const consumeSuppressedPress = useCallback(() => {
+    if (!suppressPressRef.current) return false;
+    suppressPressRef.current = false;
+    return true;
+  }, []);
+
+  // `disabled` and `draggable: false` lock an event outright; `startEditable`
+  // (per event, falling back to the grid default) allows or blocks a move.
+  const canMoveEvent = useCallback(
+    (event: CalendarEvent<T>) =>
+      !event.disabled && event.draggable !== false && (event.startEditable ?? eventStartEditable),
+    [eventStartEditable],
+  );
+
+  // The day under a grid-relative point, plus the event bar drawn there (if any).
+  // Returns null for a point on a blanked adjacent-month cell or an unselectable
+  // day, so neither can be a drag's origin or its drop target.
+  const hitTest = useCallback(
+    (x: number, y: number): { day: Date; event: CalendarEvent<T> | null } | null => {
+      const { width, height } = gridSize;
+      if (width <= 0 || height <= 0 || weeks.length === 0) return null;
+      const rowHeight = height / weeks.length;
+      const row = Math.min(weeks.length - 1, Math.max(0, Math.floor(y / rowHeight)));
+      const cols = weeks[row].length;
+      const col = Math.min(cols - 1, Math.max(0, Math.floor(x / (width / cols))));
+      const day = weeks[row][col];
+      if (!day) return null;
+      if (!showAdjacentMonths && !isSameMonth(day, date)) return null;
+      if (!isDateSelectable(day, { minDate, maxDate, isDateDisabled })) return null;
+      // Which lane row the point lands on, mirroring the bar overlay's geometry.
+      const rowLayout = weekLayouts[row] ?? EMPTY_LAYOUT;
+      const lane = Math.floor((y - row * rowHeight - BADGE_AREA) / chipMetrics.chipRowHeight);
+      const visibleLanes = monthVisibleCount(rowLayout.laneCount, capacity);
+      const segment =
+        lane >= 0 && lane < visibleLanes
+          ? rowLayout.segments.find((s) => s.lane === lane && s.startCol <= col && s.endCol >= col)
+          : undefined;
+      return { day, event: segment?.event ?? null };
+    },
+    [
+      gridSize,
+      weeks,
+      weekLayouts,
+      capacity,
+      chipMetrics,
+      showAdjacentMonths,
+      date,
+      minDate,
+      maxDate,
+      isDateDisabled,
+    ],
+  );
+
+  const beginDrag = useCallback(
+    (x: number, y: number) => {
+      // A fresh press starts a new interaction, so any guard left over from the
+      // previous one (a drag whose trailing click never reached a cell) is stale.
+      suppressPressRef.current = false;
+      movedRef.current = false;
+      const hit = hitTest(x, y);
+      if (!hit) return;
+      if (hit.event) {
+        if (!onDragEvent || !canMoveEvent(hit.event)) return;
+        applyDrag({ kind: "move", event: hit.event, from: hit.day, to: hit.day });
+        onDragStart?.(hit.event);
+        return;
+      }
+      if (onCreateEvent) applyDrag({ kind: "create", anchor: hit.day, hover: hit.day });
+    },
+    [hitTest, onDragEvent, onCreateEvent, onDragStart, canMoveEvent, applyDrag],
+  );
+
+  const extendDrag = useCallback(
+    (x: number, y: number) => {
+      const current = dragRef.current;
+      if (!current) return;
+      const hit = hitTest(x, y);
+      if (!hit) return;
+      const previous = current.kind === "create" ? current.hover : current.to;
+      if (startOfDay(hit.day).getTime() === startOfDay(previous).getTime()) return;
+      movedRef.current = true;
+      applyDrag(
+        current.kind === "create" ? { ...current, hover: hit.day } : { ...current, to: hit.day },
+      );
+    },
+    [hitTest, applyDrag],
+  );
+
+  const endDrag = useCallback(() => {
+    const current = dragRef.current;
+    applyDrag(null);
+    if (!current) return;
+    if (isWeb) suppressPressRef.current = movedRef.current;
+    if (current.kind === "create") {
+      // A stationary hold is a deliberate one-day create on native, where the
+      // gesture only starts after a long press; on the web it is just a click.
+      if (isWeb && !movedRef.current) return;
+      const range = monthCreateRange(current.anchor, current.hover);
+      onCreateEvent?.(range.start, range.end);
+      return;
+    }
+    const next = monthDropBounds(current.event, current.from, current.to);
+    if (!next) return;
+    // Reject a drop that would land the event on top of another when
+    // `eventOverlap` is off, before the consumer's handler ever sees it.
+    if (
+      eventOverlap === false &&
+      overlapsOtherEvents(events, current.event, next.start, next.end)
+    ) {
+      return;
+    }
+    onDragEvent?.(current.event, next.start, next.end);
+  }, [applyDrag, onCreateEvent, onDragEvent, eventOverlap, events]);
+
+  // Native: a pan over the grid, held first so it doesn't hijack a tap or the
+  // pager's own horizontal swipe.
+  const dragGesture = useMemo(() => {
+    if (!dragEnabled || isWeb) return undefined;
+    return Gesture.Pan()
+      .activateAfterLongPress(DRAG_LONG_PRESS_MS)
+      .runOnJS(true)
+      .onStart((event) => beginDrag(event.x, event.y))
+      .onUpdate((event) => extendDrag(event.x, event.y))
+      .onEnd((_event, success) => {
+        if (success) endDrag();
+      })
+      .onFinalize(() => {
+        if (dragRef.current) applyDrag(null);
+      });
+  }, [dragEnabled, beginDrag, extendDrag, endDrag, applyDrag]);
+
+  // Web: the cell touchables swallow the pan above, so drive the same three steps
+  // from pointer events on the grid instead. Positions come from the grid's own
+  // box, so they line up with the hit test's grid-relative coordinates.
+  const gridPoint = useCallback((clientX: number, clientY: number) => {
+    const node = gridRef.current as unknown as {
+      getBoundingClientRect?: () => { left: number; top: number };
+    } | null;
+    const rect = node?.getBoundingClientRect?.();
+    return rect ? { x: clientX - rect.left, y: clientY - rect.top } : null;
+  }, []);
+  useEffect(() => {
+    if (!isWeb || !dragEnabled) return;
+    // A drag can be released anywhere, so commit on the window rather than the grid.
+    const up = () => {
+      if (dragRef.current) endDrag();
+    };
+    const target = globalThis as unknown as {
+      addEventListener?: (type: string, cb: () => void) => void;
+      removeEventListener?: (type: string, cb: () => void) => void;
+    };
+    target.addEventListener?.("pointerup", up);
+    // Let a touch drag sketch a span instead of scrolling the page under it, and
+    // stop a sweep from text-selecting the day numbers it passes over.
+    const node = gridRef.current as unknown as {
+      style?: { touchAction?: string; userSelect?: string };
+    } | null;
+    if (node?.style) {
+      node.style.touchAction = "none";
+      node.style.userSelect = "none";
+    }
+    return () => target.removeEventListener?.("pointerup", up);
+  }, [dragEnabled, endDrag]);
+
   const renderDay = (
     day: Date,
     dayCol: number,
@@ -381,6 +637,13 @@ function MonthViewInner<T>({
     const hasBand =
       rangeBandKind({ isInRange, isRangeStart, isRangeEnd }, fillCellOnSelection) !== "none";
     const dayKey = day.toISOString();
+    // Tint the days a drag is currently over: every day of a create sweep, or the
+    // one an event would land on.
+    const isDragPreview =
+      isInCreateSpan(drag, day) ||
+      (drag?.kind === "move" &&
+        isSameCalendarDay(day, drag.to) &&
+        !isSameCalendarDay(day, drag.from));
     // A hovered, non-filled day gets the subtle badge highlight on the web, but only
     // in the events-free picker. The events calendar (month and list views) has no
     // hover, matching the dom renderer (its events-mode cell omits it).
@@ -396,7 +659,16 @@ function MonthViewInner<T>({
           : theme.colors.textDisabled;
 
     // Disabled days ignore taps; pass the guards through so a press never fires.
-    const handlePressDay = isDisabled || !onPressDay ? undefined : () => onPressDay(day);
+    // `onPressCell` receives the same day at midnight, so one handler covers both
+    // the month grid and the week/day grid's empty slots.
+    const handlePressDay =
+      isDisabled || (!onPressDay && !onPressCell)
+        ? undefined
+        : () => {
+            if (consumeSuppressedPress()) return;
+            onPressDay?.(day);
+            onPressCell?.(startOfDay(day));
+          };
     const handleLongPressDay =
       isDisabled || !onLongPressDay ? undefined : () => onLongPressDay(day);
 
@@ -417,6 +689,9 @@ function MonthViewInner<T>({
           borderColor: theme.colors.gridLine,
         },
         highlightWeekends && isWeekend(day) && { backgroundColor: theme.colors.weekendBackground },
+        // The drag preview sits on top of the weekend tint: the span being swept
+        // out, or the day an event is about to land on.
+        isDragPreview && { backgroundColor: theme.colors.rangeBackground },
         theme.containers.dayCell,
       ],
     });
@@ -441,7 +716,7 @@ function MonthViewInner<T>({
             })}
         onPress={handlePressDay}
         onLongPress={handleLongPressDay}
-        disabled={isDisabled || (!onPressDay && !onLongPressDay)}
+        disabled={isDisabled || (!onPressDay && !onLongPressDay && !onPressCell)}
         // Web only: track hover for the badge highlight, and (when drag-select is
         // wired) relay pointer down/enter so MonthList can extend a range as the
         // pressed pointer sweeps across cells. Native uses a pan, no hover.
@@ -573,8 +848,10 @@ function MonthViewInner<T>({
   };
 
   const handleLayout = (event: LayoutChangeEvent) => {
-    const next = event.nativeEvent.layout.height;
-    setGridHeight((prev) => (prev === next ? prev : next));
+    const { width, height } = event.nativeEvent.layout;
+    setGridSize((prev) =>
+      prev.width === width && prev.height === height ? prev : { width, height },
+    );
   };
 
   return (
@@ -655,77 +932,120 @@ function MonthViewInner<T>({
           </Pressable>
         </Modal>
       ) : null}
-      <View {...slot("grid", { base: styles.container })} onLayout={handleLayout}>
-        {weeks.map((week, weekIndex) => {
-          // Spanning bars for this row (laid out once in `weekLayouts`). A multi-day
-          // event is one bar across its columns, stacked into lanes; the bars render
-          // in an overlay so they can span cells, and the cells reserve the lane rows
-          // so "+more" sits below them. `visibleLanes` mirrors the per-day cap.
-          const rowLayout = weekLayouts[weekIndex] ?? EMPTY_LAYOUT;
-          const visibleLanes = monthVisibleCount(rowLayout.laneCount, capacity);
-          const cols = week.length;
-          // With adjacent months hidden, clamp bars to the current-month columns so
-          // none draw over the blank leading/trailing cells.
-          let firstVisCol = 0;
-          let lastVisCol = cols - 1;
-          if (showGrid && !showAdjacentMonths) {
-            const first = week.findIndex((d) => isSameMonth(d, date));
-            if (first !== -1) {
-              firstVisCol = first;
-              lastVisCol = cols - 1 - [...week].reverse().findIndex((d) => isSameMonth(d, date));
+      <MonthGridSurface gesture={dragGesture}>
+        <View
+          ref={gridRef}
+          testID="month-grid"
+          {...slot("grid", { base: styles.container })}
+          onLayout={handleLayout}
+          {...(isWeb && dragEnabled
+            ? {
+                onPointerDown: (event: RNPointerEvent) => {
+                  const point = gridPoint(event.nativeEvent.clientX, event.nativeEvent.clientY);
+                  if (point) beginDrag(point.x, point.y);
+                },
+                onPointerMove: (event: RNPointerEvent) => {
+                  if (!dragRef.current) return;
+                  const point = gridPoint(event.nativeEvent.clientX, event.nativeEvent.clientY);
+                  if (point) extendDrag(point.x, point.y);
+                },
+              }
+            : null)}
+        >
+          {weeks.map((week, weekIndex) => {
+            // Spanning bars for this row (laid out once in `weekLayouts`). A multi-day
+            // event is one bar across its columns, stacked into lanes; the bars render
+            // in an overlay so they can span cells, and the cells reserve the lane rows
+            // so "+more" sits below them. `visibleLanes` mirrors the per-day cap.
+            const rowLayout = weekLayouts[weekIndex] ?? EMPTY_LAYOUT;
+            const visibleLanes = monthVisibleCount(rowLayout.laneCount, capacity);
+            const cols = week.length;
+            // With adjacent months hidden, clamp bars to the current-month columns so
+            // none draw over the blank leading/trailing cells.
+            let firstVisCol = 0;
+            let lastVisCol = cols - 1;
+            if (showGrid && !showAdjacentMonths) {
+              const first = week.findIndex((d) => isSameMonth(d, date));
+              if (first !== -1) {
+                firstVisCol = first;
+                lastVisCol = cols - 1 - [...week].reverse().findIndex((d) => isSameMonth(d, date));
+              }
             }
-          }
-          return (
-            <View
-              {...slot("week", { base: styles.weekRow, themed: theme.containers.weekRow })}
-              key={week[0].toISOString()}
-            >
-              {week.map((day, dayCol) => renderDay(day, dayCol, rowLayout, visibleLanes))}
-              {showGrid ? (
-                <View style={[StyleSheet.absoluteFill, { pointerEvents: "box-none" }]}>
-                  {rowLayout.segments
-                    .filter((seg) => seg.lane < visibleLanes)
-                    .map((seg) => {
-                      const startCol = Math.max(seg.startCol, firstVisCol);
-                      const endCol = Math.min(seg.endCol, lastVisCol);
-                      if (startCol > endCol) return null;
-                      return (
-                        <View
-                          key={`bar-${seg.event.start.toISOString()}:${seg.event.title}:${seg.lane}`}
-                          style={{
-                            position: "absolute",
-                            left: pct((startCol / cols) * 100),
-                            width: pct(((endCol - startCol + 1) / cols) * 100),
-                            top: BADGE_AREA + seg.lane * chipMetrics.chipRowHeight,
-                            height: chipMetrics.chipHeight,
-                            paddingHorizontal: CHIP_INSET_H,
-                            pointerEvents: "box-none",
-                          }}
-                        >
-                          <RenderEventComponent
-                            event={seg.event}
-                            mode="month"
-                            isAllDay={isAllDayEvent(seg.event)}
-                            onPress={
-                              disableMonthEventCellPress ? () => {} : () => onPressEvent(seg.event)
-                            }
-                            onLongPress={
-                              disableMonthEventCellPress || !onLongPressEvent
-                                ? undefined
-                                : () => onLongPressEvent(seg.event)
-                            }
-                          />
-                        </View>
-                      );
-                    })}
-                </View>
-              ) : null}
-            </View>
-          );
-        })}
-      </View>
+            return (
+              <View
+                {...slot("week", { base: styles.weekRow, themed: theme.containers.weekRow })}
+                key={week[0].toISOString()}
+              >
+                {week.map((day, dayCol) => renderDay(day, dayCol, rowLayout, visibleLanes))}
+                {showGrid ? (
+                  <View style={[StyleSheet.absoluteFill, { pointerEvents: "box-none" }]}>
+                    {rowLayout.segments
+                      .filter((seg) => seg.lane < visibleLanes)
+                      .map((seg) => {
+                        const startCol = Math.max(seg.startCol, firstVisCol);
+                        const endCol = Math.min(seg.endCol, lastVisCol);
+                        if (startCol > endCol) return null;
+                        // Fade the bar being carried, so the tinted drop target reads
+                        // as where it is going and this as where it came from.
+                        const isDragged = drag?.kind === "move" && drag.event === seg.event;
+                        return (
+                          <View
+                            key={`bar-${seg.event.start.toISOString()}:${seg.event.title}:${seg.lane}`}
+                            style={{
+                              position: "absolute",
+                              left: pct((startCol / cols) * 100),
+                              width: pct(((endCol - startCol + 1) / cols) * 100),
+                              top: BADGE_AREA + seg.lane * chipMetrics.chipRowHeight,
+                              height: chipMetrics.chipHeight,
+                              paddingHorizontal: CHIP_INSET_H,
+                              // Let a sweep in progress reach the cells underneath.
+                              pointerEvents: drag ? "none" : "box-none",
+                              opacity: isDragged ? DRAGGED_BAR_OPACITY : 1,
+                            }}
+                          >
+                            <RenderEventComponent
+                              event={seg.event}
+                              mode="month"
+                              isAllDay={isAllDayEvent(seg.event)}
+                              onPress={
+                                disableMonthEventCellPress
+                                  ? () => {}
+                                  : () => {
+                                      if (consumeSuppressedPress()) return;
+                                      onPressEvent(seg.event);
+                                    }
+                              }
+                              onLongPress={
+                                disableMonthEventCellPress || !onLongPressEvent
+                                  ? undefined
+                                  : () => onLongPressEvent(seg.event)
+                              }
+                            />
+                          </View>
+                        );
+                      })}
+                  </View>
+                ) : null}
+              </View>
+            );
+          })}
+        </View>
+      </MonthGridSurface>
     </View>
   );
+}
+
+// The grid, wrapped in a GestureDetector only when a month drag is wired up, so
+// the picker (and any month without drag handlers) mounts no gesture at all.
+function MonthGridSurface({
+  gesture,
+  children,
+}: {
+  gesture?: ReturnType<typeof Gesture.Pan>;
+  children: ReactElement;
+}): ReactElement {
+  if (!gesture) return children;
+  return <GestureDetector gesture={gesture}>{children}</GestureDetector>;
 }
 
 /**

--- a/packages/native/src/components/TimeGrid.tsx
+++ b/packages/native/src/components/TimeGrid.tsx
@@ -58,6 +58,8 @@ import type {
   BusinessHoursBand,
   CalendarEvent,
   CalendarMode,
+  EventDragHandler,
+  EventDragStartHandler,
   EventKeyExtractor,
   RenderEvent,
   TimeGridMode,
@@ -219,23 +221,10 @@ function DragGhost<T>({
   );
 }
 
-/**
- * Called when an event is dragged (moved or resized) to new start/end times.
- * Return `false` to reject the drop — the event snaps back to where it started
- * (e.g. to forbid overlaps or out-of-bounds slots). Any other return accepts it.
- */
-export type EventDragHandler<T> = (
-  event: CalendarEvent<T>,
-  start: Date,
-  end: Date,
-) => void | boolean;
-/**
- * Called when a move or resize gesture begins, before any change is committed:
- * on grab for a move (after the long-press), and when the resize drag starts.
- * Handy for haptic feedback (e.g. `expo-haptics`). Requires drag to be enabled
- * via `onDragEvent`.
- */
-export type EventDragStartHandler<T> = (event: CalendarEvent<T>) => void;
+// The drag handler types live in `../types` so the Reanimated-free month view can
+// share them; re-exported here because both are part of this module's public API.
+export type { EventDragHandler, EventDragStartHandler } from "../types";
+
 // Hour labels are nudged up so the number sits centred on its grid line. Pad the
 // scroll content by the same amount so the top-most label is never clipped.
 const HOUR_LABEL_TOP_INSET = 12;

--- a/packages/native/src/components/__tests__/MonthPager.test.tsx
+++ b/packages/native/src/components/__tests__/MonthPager.test.tsx
@@ -65,3 +65,28 @@ describe("MonthPager event updates", () => {
     expect(getByLabelText(/6 January 2026, 1 event$/)).toBeTruthy();
   });
 });
+
+describe("MonthPager title", () => {
+  const date = new Date(2026, 0, 6);
+
+  it("renders the built-in 'MMMM yyyy' title by default", () => {
+    const { getByText } = render(
+      <Calendar mode="month" date={date} events={[]} onChangeDate={noop} onPressEvent={noop} />,
+    );
+    expect(getByText("January 2026")).toBeTruthy();
+  });
+
+  it("hides it with showTitle={false}, so an app header can own the label", () => {
+    const { queryByText } = render(
+      <Calendar
+        mode="month"
+        date={date}
+        events={[]}
+        showTitle={false}
+        onChangeDate={noop}
+        onPressEvent={noop}
+      />,
+    );
+    expect(queryByText("January 2026")).toBeNull();
+  });
+});

--- a/packages/native/src/components/__tests__/MonthView.test.tsx
+++ b/packages/native/src/components/__tests__/MonthView.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, within } from "@testing-library/react-native";
+import { act, fireEvent, render, within } from "@testing-library/react-native";
 import { StyleSheet, Text, type ViewStyle } from "react-native";
 import { CalendarThemeProvider, defaultTheme, mergeTheme } from "../../theme";
 import type { CalendarEvent } from "../../types";
@@ -16,6 +16,19 @@ const baseProps = {
 
 const backgroundColorOf = (node: { props: { style?: unknown } }) =>
   StyleSheet.flatten(node.props.style as ViewStyle)?.backgroundColor;
+
+// The absolutely-positioned wrapper a month event bar is drawn in, found from a
+// node inside the chip. The chip's own box sets an opacity of its own, so the
+// wrapper is identified by its positioning, not by carrying an opacity.
+const barWrapperOf = (node: { parent: unknown; props: { style?: unknown } }) => {
+  let current: typeof node | null = node;
+  while (current) {
+    const style = StyleSheet.flatten(current.props.style as ViewStyle);
+    if (style?.position === "absolute") return style;
+    current = current.parent as typeof node | null;
+  }
+  throw new Error("no absolutely-positioned bar wrapper above this node");
+};
 
 describe("MonthView selection", () => {
   it("announces a single selected day", () => {
@@ -292,5 +305,285 @@ describe("MonthView multi-day events", () => {
     const { getAllByText } = render(<MonthView {...baseProps} events={span} />);
     // One bar spanning two days, not a chip repeated on each day.
     expect(getAllByText("Trip")).toHaveLength(1);
+  });
+});
+
+describe("MonthView onPressCell", () => {
+  it("fires with the tapped day at midnight, alongside onPressDay", () => {
+    const onPressCell = jest.fn();
+    const onPressDay = jest.fn();
+    const { getByLabelText } = render(
+      <MonthView {...baseProps} onPressCell={onPressCell} onPressDay={onPressDay} />,
+    );
+    fireEvent.press(getByLabelText(/15 June 2026/));
+    expect(onPressCell).toHaveBeenCalledWith(new Date(2026, 5, 15));
+    expect(onPressDay).toHaveBeenCalledTimes(1);
+  });
+
+  it("fires on its own when only onPressCell is wired", () => {
+    const onPressCell = jest.fn();
+    const { getByLabelText } = render(<MonthView {...baseProps} onPressCell={onPressCell} />);
+    fireEvent.press(getByLabelText(/15 June 2026/));
+    expect(onPressCell).toHaveBeenCalledWith(new Date(2026, 5, 15));
+  });
+
+  it("ignores a tap on a disabled day", () => {
+    const onPressCell = jest.fn();
+    const { getByLabelText } = render(
+      <MonthView
+        {...baseProps}
+        isDateDisabled={(day) => day.getDate() === 15}
+        onPressCell={onPressCell}
+      />,
+    );
+    fireEvent.press(getByLabelText(/15 June 2026/));
+    expect(onPressCell).not.toHaveBeenCalled();
+  });
+});
+
+describe("MonthView drag", () => {
+  // June 2026 with weekStartsOn=0 renders five week rows starting Sun 31 May, so
+  // at 700x600 each cell is 100 wide and 120 tall. Row 2 is Sun 14 - Sat 20 June.
+  const GRID = { width: 700, height: 600 };
+  const ROW_HEIGHT = GRID.height / 5;
+  const COL_WIDTH = GRID.width / 7;
+  // Vertically: inside the date badge is empty cell; just past it is the first
+  // event lane, where a bar can be grabbed.
+  const EMPTY_Y = 8;
+  const LANE_Y = 32;
+  // Column centre for a weekday, 0 = Sunday.
+  const colX = (weekday: number) => weekday * COL_WIDTH + COL_WIDTH / 2;
+  const rowY = (row: number, offset: number) => row * ROW_HEIGHT + offset;
+
+  const standup: CalendarEvent = {
+    title: "Standup",
+    start: new Date(2026, 5, 15, 9, 30), // Mon 15 June
+    end: new Date(2026, 5, 15, 10, 15),
+  };
+
+  // The pan the MonthView built for this render (the mock records every builder).
+  const lastGesture = () => {
+    const { __gestures } = require("react-native-gesture-handler");
+    return __gestures[__gestures.length - 1];
+  };
+
+  const mount = (ui: React.ReactElement) => {
+    const view = render(ui);
+    // react-test-renderer never lays out, so feed the grid its box by hand.
+    fireEvent(view.getByTestId("month-grid"), "layout", {
+      nativeEvent: { layout: { x: 0, y: 0, ...GRID } },
+    });
+    return view;
+  };
+
+  // The gesture callbacks are invoked straight from the recording mock, outside
+  // React's event system, so the preview state they set needs its own act().
+  const drag = (from: { x: number; y: number }, to: { x: number; y: number }) => {
+    const { handlers } = lastGesture();
+    act(() => {
+      handlers.onStart(from);
+      handlers.onUpdate(to);
+      handlers.onEnd({}, true);
+    });
+  };
+  // Grab and move without releasing, so the in-flight preview can be inspected.
+  const dragTo = (from: { x: number; y: number }, to: { x: number; y: number }) => {
+    const { handlers } = lastGesture();
+    act(() => {
+      handlers.onStart(from);
+      handlers.onUpdate(to);
+    });
+  };
+
+  it("mounts no gesture when neither drag handler is wired", () => {
+    const { __gestures } = require("react-native-gesture-handler");
+    const before = __gestures.length;
+    mount(<MonthView {...baseProps} events={[standup]} />);
+    expect(__gestures.length).toBe(before);
+  });
+
+  describe("to create", () => {
+    it("fires onCreateEvent with the all-day span swept across empty cells", () => {
+      const onCreateEvent = jest.fn();
+      mount(<MonthView {...baseProps} events={[standup]} onCreateEvent={onCreateEvent} />);
+      // Tue 16 June -> Thu 18 June, along the empty top of each cell.
+      drag({ x: colX(2), y: rowY(2, EMPTY_Y) }, { x: colX(4), y: rowY(2, EMPTY_Y) });
+
+      expect(onCreateEvent).toHaveBeenCalledTimes(1);
+      const [start, end] = onCreateEvent.mock.calls[0] as [Date, Date];
+      expect(start).toEqual(new Date(2026, 5, 16));
+      // End is exclusive: midnight after the last swept day.
+      expect(end).toEqual(new Date(2026, 5, 19));
+    });
+
+    it("commits a stationary hold as a single all-day event", () => {
+      const onCreateEvent = jest.fn();
+      mount(<MonthView {...baseProps} events={[standup]} onCreateEvent={onCreateEvent} />);
+      const point = { x: colX(2), y: rowY(2, EMPTY_Y) };
+      drag(point, point);
+
+      const [start, end] = onCreateEvent.mock.calls[0] as [Date, Date];
+      expect(start).toEqual(new Date(2026, 5, 16));
+      expect(end).toEqual(new Date(2026, 5, 17));
+    });
+
+    it("sweeps backwards to the same ordered span", () => {
+      const onCreateEvent = jest.fn();
+      mount(<MonthView {...baseProps} events={[standup]} onCreateEvent={onCreateEvent} />);
+      drag({ x: colX(4), y: rowY(2, EMPTY_Y) }, { x: colX(2), y: rowY(2, EMPTY_Y) });
+
+      const [start, end] = onCreateEvent.mock.calls[0] as [Date, Date];
+      expect(start).toEqual(new Date(2026, 5, 16));
+      expect(end).toEqual(new Date(2026, 5, 19));
+    });
+
+    it("tints every day of the span while the sweep is in flight", () => {
+      const view = mount(<MonthView {...baseProps} events={[standup]} onCreateEvent={() => {}} />);
+      dragTo({ x: colX(2), y: rowY(2, EMPTY_Y) }, { x: colX(4), y: rowY(2, EMPTY_Y) });
+
+      for (const day of [/16 June 2026/, /17 June 2026/, /18 June 2026/]) {
+        expect(backgroundColorOf(view.getByLabelText(day))).toBe(
+          defaultTheme.colors.rangeBackground,
+        );
+      }
+      // The day just outside the sweep keeps its own background.
+      expect(backgroundColorOf(view.getByLabelText(/19 June 2026/))).toBeUndefined();
+    });
+
+    it("does not start on a disabled day", () => {
+      const onCreateEvent = jest.fn();
+      mount(
+        <MonthView
+          {...baseProps}
+          events={[standup]}
+          isDateDisabled={(day) => day.getDate() === 16}
+          onCreateEvent={onCreateEvent}
+        />,
+      );
+      drag({ x: colX(2), y: rowY(2, EMPTY_Y) }, { x: colX(4), y: rowY(2, EMPTY_Y) });
+      expect(onCreateEvent).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("to reschedule", () => {
+    it("fires onDragEvent with both ends shifted by the days dragged", () => {
+      const onDragEvent = jest.fn();
+      const onDragStart = jest.fn();
+      mount(
+        <MonthView
+          {...baseProps}
+          events={[standup]}
+          onDragEvent={onDragEvent}
+          onDragStart={onDragStart}
+        />,
+      );
+      // Grab the bar on Mon 15 June and drop it on Thu 18 June.
+      drag({ x: colX(1), y: rowY(2, LANE_Y) }, { x: colX(4), y: rowY(2, LANE_Y) });
+
+      expect(onDragStart).toHaveBeenCalledWith(standup);
+      expect(onDragEvent).toHaveBeenCalledTimes(1);
+      const [event, start, end] = onDragEvent.mock.calls[0] as [CalendarEvent, Date, Date];
+      expect(event).toBe(standup);
+      // The time of day and the 45-minute duration survive the move.
+      expect(start).toEqual(new Date(2026, 5, 18, 9, 30));
+      expect(end).toEqual(new Date(2026, 5, 18, 10, 15));
+    });
+
+    it("carries an event into another week row", () => {
+      const onDragEvent = jest.fn();
+      mount(<MonthView {...baseProps} events={[standup]} onDragEvent={onDragEvent} />);
+      // Row 3 is Sun 21 - Sat 27 June; the same weekday there is Mon 22 June.
+      drag({ x: colX(1), y: rowY(2, LANE_Y) }, { x: colX(1), y: rowY(3, LANE_Y) });
+
+      const [, start] = onDragEvent.mock.calls[0] as [CalendarEvent, Date, Date];
+      expect(start).toEqual(new Date(2026, 5, 22, 9, 30));
+    });
+
+    it("commits nothing when the drop lands back on the day it started", () => {
+      const onDragEvent = jest.fn();
+      mount(<MonthView {...baseProps} events={[standup]} onDragEvent={onDragEvent} />);
+      const point = { x: colX(1), y: rowY(2, LANE_Y) };
+      drag(point, point);
+      expect(onDragEvent).not.toHaveBeenCalled();
+    });
+
+    it("does not pick up an event locked with draggable: false", () => {
+      const onDragEvent = jest.fn();
+      mount(
+        <MonthView
+          {...baseProps}
+          events={[{ ...standup, draggable: false }]}
+          onDragEvent={onDragEvent}
+        />,
+      );
+      drag({ x: colX(1), y: rowY(2, LANE_Y) }, { x: colX(4), y: rowY(2, LANE_Y) });
+      expect(onDragEvent).not.toHaveBeenCalled();
+    });
+
+    it("honours eventStartEditable={false} as the grid-wide lock", () => {
+      const onDragEvent = jest.fn();
+      mount(
+        <MonthView
+          {...baseProps}
+          events={[standup]}
+          eventStartEditable={false}
+          onDragEvent={onDragEvent}
+        />,
+      );
+      drag({ x: colX(1), y: rowY(2, LANE_Y) }, { x: colX(4), y: rowY(2, LANE_Y) });
+      expect(onDragEvent).not.toHaveBeenCalled();
+    });
+
+    it("rejects a drop onto an overlapping event when eventOverlap is false", () => {
+      const onDragEvent = jest.fn();
+      const clash: CalendarEvent = {
+        title: "Clash",
+        start: new Date(2026, 5, 18, 9, 30),
+        end: new Date(2026, 5, 18, 10, 15),
+      };
+      mount(
+        <MonthView
+          {...baseProps}
+          events={[standup, clash]}
+          eventOverlap={false}
+          onDragEvent={onDragEvent}
+        />,
+      );
+      drag({ x: colX(1), y: rowY(2, LANE_Y) }, { x: colX(4), y: rowY(2, LANE_Y) });
+      expect(onDragEvent).not.toHaveBeenCalled();
+    });
+
+    it("fades the carried bar and tints only the day it would land on", () => {
+      const view = mount(<MonthView {...baseProps} events={[standup]} onDragEvent={() => {}} />);
+      dragTo({ x: colX(1), y: rowY(2, LANE_Y) }, { x: colX(4), y: rowY(2, LANE_Y) });
+
+      expect(backgroundColorOf(view.getByLabelText(/18 June 2026/))).toBe(
+        defaultTheme.colors.rangeBackground,
+      );
+      // Not the day it came from, and not an untouched day in between.
+      expect(backgroundColorOf(view.getByLabelText(/15 June 2026/))).toBeUndefined();
+      expect(backgroundColorOf(view.getByLabelText(/17 June 2026/))).toBeUndefined();
+      const bar = barWrapperOf(view.getByText("Standup"));
+      expect(bar.opacity).toBeLessThan(1);
+      // Non-interactive mid-drag, so the sweep reaches the cells underneath.
+      expect(bar.pointerEvents).toBe("none");
+    });
+
+    it("sweeps a new span instead when the grab misses every bar", () => {
+      const onCreateEvent = jest.fn();
+      const onDragEvent = jest.fn();
+      mount(
+        <MonthView
+          {...baseProps}
+          events={[standup]}
+          onCreateEvent={onCreateEvent}
+          onDragEvent={onDragEvent}
+        />,
+      );
+      // Same lane row, but a column the bar does not cover.
+      drag({ x: colX(3), y: rowY(2, LANE_Y) }, { x: colX(5), y: rowY(2, LANE_Y) });
+      expect(onDragEvent).not.toHaveBeenCalled();
+      expect(onCreateEvent).toHaveBeenCalledTimes(1);
+    });
   });
 });

--- a/packages/native/src/types.ts
+++ b/packages/native/src/types.ts
@@ -26,6 +26,25 @@ export type {
   WeekStartsOn,
 } from "@super-calendar/core";
 
+/**
+ * Called when an event is dragged (moved or resized) to new start/end times.
+ * Return `false` to reject the drop — the event snaps back to where it started
+ * (e.g. to forbid overlaps or out-of-bounds slots). Any other return accepts it.
+ */
+export type EventDragHandler<T> = (
+  event: CalendarEvent<T>,
+  start: Date,
+  end: Date,
+) => void | boolean;
+
+/**
+ * Called when a move or resize gesture begins, before any change is committed:
+ * on grab for a move (after the long-press), and when the resize drag starts.
+ * Handy for haptic feedback (e.g. `expo-haptics`). Requires drag to be enabled
+ * via `onDragEvent`.
+ */
+export type EventDragStartHandler<T> = (event: CalendarEvent<T>) => void;
+
 // The React Native render contract lives here, not in core: it references
 // Reanimated (`SharedValue`) and React Native (`ViewStyle`) types, which must
 // not leak into the platform-free core.

--- a/tests/renderer-parity.test.ts
+++ b/tests/renderer-parity.test.ts
@@ -48,9 +48,6 @@ const DOM_PLATFORM_PROPS: Record<string, Set<string>> = {
     "showTitle",
     "showWeekdays",
     "keyboardDayNavigation",
-    // Web-only for now: pointer drag-to-create a day span (native month drag lands
-    // with a gesture-handler pass).
-    "onCreateEvent",
   ]),
   // pastMonths/futureMonths size the dom scroll window (native virtualizes by date).
   // keyboardDayNavigation is web-only (see MonthView).


### PR DESCRIPTION
## Summary

Closes the three gaps issue #40 reports in `mode="month"`, on both renderers. A new `showTitle` prop on `Calendar` (default `true`) hides the built-in "Month Year" label when your own header already shows it, and a day-cell tap now fires `onPressCell` with that day at midnight alongside `onPressDay`, so one create-handler works across month and week/day. Month cells and bars are also draggable: `onCreateEvent` sweeps out an all-day span across days and `onDragEvent` drops an event on another day, shifting both ends by whole days so the time of day and duration are preserved — honouring the existing `draggable` / `startEditable` / `eventStartEditable` / `eventOverlap` locks and the `false` return to reject a drop. The shared semantics live in core as `monthCreateRange` / `monthDropBounds`, which let `onCreateEvent` come off the `DOM_PLATFORM_PROPS` allowlist in `renderer-parity.test.ts` — the gap that file's comment flagged is now closed.

Browser testing surfaced two bugs that are fixed here: the post-drag click guard could outlive its interaction and swallow the next legitimate click (pre-existing in dom drag-to-create), and a sweep text-selected the day numbers it passed over.

## Testing

- `lint`, `format`, `typecheck` (root + both examples), `test` (506 passing, +35 new), `build`, and `attw` + `publint` per package are clean.
- Drove both renderers in a real browser with real pointer input: create and reschedule on dom, and the same two on the native renderer via react-native-web; confirmed the mid-drag tint, that no `data-drop` leaks after release, and that a plain click still drills into the day view.
- `mint broken-links` could not run locally (the Mintlify CLI fails to boot on a missing `openapi-types` subpath, unrelated to this change); the added links were checked by hand.

## Note for review

The dom's drag-to-create previously had no default visual, only `data-creating` for consumers to style. Shipping reschedule with feedback but leaving create blank would have been inconsistent, so both now get a default `rangeBackground` tint via the `day` slot's *themed* styles (setting `classNames.day` still drops it entirely) — a small visual change to already-shipped behaviour, easy to revert if unwanted.

Closes #40