### PR TITLE
feat: move time-grid events past midnight

### DIFF
--- a/README.md
+++ b/README.md
@@ -296,7 +296,8 @@ Pass `onDragEvent` to make events draggable on the week/day grid. Move an event
 (**long-press** it on native, **click-drag** it on web) — drag **vertically to
 change the time, horizontally to move it to another day** (within the visible
 range) — or **drag the grip at its top or bottom edge** to change the start or the
-end. The handler receives
+end. Dragging past the end of the day lets an event's end run into the next one,
+previewed at the top of the next column. The handler receives
 the new `start`/`end`, snapped to `dragStepMinutes` (default 15) — update your own
 event state in response. On web a plain click still selects and right-click still
 fires, so drag coexists with both:

--- a/docs/demo.mdx
+++ b/docs/demo.mdx
@@ -46,7 +46,9 @@ real library, no mocks.
 - **Switch modes** with the tabs: month, week, 3-day, day, schedule.
 - **Pinch / Ctrl-scroll** on the week or day grid to zoom the hours.
 - **Click-drag an event** vertically to change its time, horizontally to move it
-  to another day. The exam is "locked" — its drop is rejected and it snaps back.
+  to another day. Drag the evening gig down past the end of its day and it
+  continues on the next one. The exam is "locked": its drop is rejected and it
+  snaps back.
 - **Drag the grip** at an event's bottom edge to resize it.
 - **Click-drag empty space** to create an event; press **Escape** mid-drag to
   cancel.

--- a/docs/guides/dragging.mdx
+++ b/docs/guides/dragging.mdx
@@ -24,6 +24,19 @@ range). New `start`/`end` are snapped to `dragStepMinutes` (default 15).
 />
 ```
 
+### Move an event past midnight
+
+A move keeps its duration, so dragging an event **down past the end of the day**
+lets its end run into the next one: the box cuts off at the day boundary and the
+remainder previews at the top of the next column, exactly where the committed
+event will render. The **start** stays in the day you dropped it on (it stops one
+`dragStepMinutes` step before the end of the day), so a move to a different day is
+still the horizontal drag.
+
+`onDragEvent` then receives a `start` and `end` on different dates. Dragging any
+day's segment of the resulting multi-day event moves the whole thing, so it never
+gets clipped to the day you grabbed.
+
 ### Hide the drag handle
 
 By default a small grip shows at each draggable event's bottom edge. Set

--- a/docs/guides/headless.mdx
+++ b/docs/guides/headless.mdx
@@ -125,7 +125,8 @@ Every helper below is pure (safe in tests, on a server, or in a worker). See the
 TypeScript types for exact signatures.
 
 - **Drag math** — `cellRangeFromDrag` (a sweep to start/end), `resolveDraggedBounds`
-  (a move/resize to snapped bounds), `snapDeltaMinutes`, `shiftMinutes`.
+  (a move/resize to snapped bounds), `clampMoveStartMinutes` (holds a moved start
+  inside the visible hour window), `snapDeltaMinutes`, `shiftMinutes`.
 - **Event display** — `eventTimeLabel`, `eventAccessibilityLabel`,
   `titleNumberOfLines` / `titleEllipsizeMode`, `isTimeVisibleAtHeight`, `formatHour`
   (the shared time-grid hour-axis label both renderers default to).

--- a/docs/reference/api.mdx
+++ b/docs/reference/api.mdx
@@ -117,3 +117,9 @@ and `minDate` / `maxDate` / `isDateDisabled` for disabled days. See the
     `MonthEventSegment`, `MonthWeekEvents`, `MonthListProps`, `CalendarSlot`, `SlotStyleProps`
   </Card>
 </CardGroup>
+
+## Core-only helpers
+
+`@super-calendar/core` also exports `clampMoveStartMinutes`. Use it when a custom
+time-grid drag must keep the moved start inside the visible hour window without
+shortening an event that continues past midnight.

--- a/jest.setup.components.js
+++ b/jest.setup.components.js
@@ -13,15 +13,19 @@ jest.mock("react-native-gesture-handler", () => {
   const gestures = [];
   const makeChain = () => {
     const handlers = {};
+    const calls = {};
     const chain = new Proxy(() => chain, {
       get: (_target, prop) =>
         prop === "handlers"
           ? handlers
-          : (...args) => {
-              const callback = args.find((arg) => typeof arg === "function");
-              if (callback) handlers[prop] = callback;
-              return chain;
-            },
+          : prop === "calls"
+            ? calls
+            : (...args) => {
+                calls[prop] = args;
+                const callback = args.find((arg) => typeof arg === "function");
+                if (callback) handlers[prop] = callback;
+                return chain;
+              },
     });
     gestures.push(chain);
     return chain;
@@ -36,18 +40,52 @@ jest.mock("react-native-gesture-handler", () => {
 });
 
 jest.mock("react-native-reanimated", () => {
+  const React = require("react");
   const { View } = require("react-native");
+  const reactions = [];
+  const flushAnimatedReactions = () => {
+    for (const reaction of [...reactions]) {
+      const next = reaction.prepare();
+      const previous = reaction.previous;
+      reaction.previous = next;
+      if (next !== previous) reaction.react(next, previous);
+    }
+  };
   return {
     __esModule: true,
     default: { View, ScrollView: View, createAnimatedComponent: (component) => component },
     useAnimatedStyle: (factory) => factory(),
-    useDerivedValue: (factory) => ({ value: factory() }),
-    useSharedValue: (initial) => ({ value: initial }),
+    useDerivedValue: (factory) => {
+      const factoryRef = React.useRef(factory);
+      factoryRef.current = factory;
+      const valueRef = React.useRef();
+      if (!valueRef.current) {
+        valueRef.current = Object.defineProperty({}, "value", {
+          configurable: true,
+          get: () => factoryRef.current(),
+        });
+      }
+      return valueRef.current;
+    },
+    useSharedValue: (initial) => React.useRef({ value: initial }).current,
     useAnimatedRef: () => ({ current: null }),
-    useAnimatedReaction: () => {},
+    useAnimatedReaction: (prepare, react) => {
+      const reactionRef = React.useRef();
+      if (!reactionRef.current) {
+        const current = prepare();
+        reactionRef.current = { prepare, react, previous: current };
+        reactions.push(reactionRef.current);
+        react(current, null);
+      } else {
+        reactionRef.current.prepare = prepare;
+        reactionRef.current.react = react;
+      }
+    },
     useAnimatedScrollHandler: () => () => {},
     useReducedMotion: () => false,
     runOnJS: (fn) => fn,
     scrollTo: () => {},
+    __reactions: reactions,
+    __flushAnimatedReactions: flushAnimatedReactions,
   };
 });

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -43,6 +43,16 @@ import { useDateRange } from "@super-calendar/core";
 const range = useDateRange({ mode: "range" });
 ```
 
+For a custom time-grid drag, `clampMoveStartMinutes` keeps the moved event's
+start inside the visible hour window while allowing its unchanged duration to
+carry the end past midnight:
+
+```ts
+import { clampMoveStartMinutes } from "@super-calendar/core";
+
+const startMinutes = clampMoveStartMinutes(rawStartMinutes, minHour, maxHour, snapMinutes);
+```
+
 ## Documentation
 
 See the [full documentation](https://super-calendar.afonsojramos.me) and the [API reference](https://super-calendar.afonsojramos.me/reference/api).

--- a/packages/core/src/utils/__tests__/drag.test.ts
+++ b/packages/core/src/utils/__tests__/drag.test.ts
@@ -1,6 +1,7 @@
 import type { CalendarEvent } from "../../types";
 import {
   cellRangeFromDrag,
+  clampMoveStartMinutes,
   eventsOverlap,
   overlapsOtherEvents,
   pageStepDays,
@@ -86,6 +87,31 @@ describe("snapDeltaMinutes", () => {
   it("returns 0 for a degenerate grid", () => {
     expect(snapDeltaMinutes(50, 0, 15)).toBe(0);
     expect(snapDeltaMinutes(50, 64, 0)).toBe(0);
+  });
+});
+
+describe("clampMoveStartMinutes", () => {
+  it("leaves a start inside the window alone", () => {
+    expect(clampMoveStartMinutes(9 * 60, 0, 24, 15)).toBe(9 * 60);
+  });
+
+  it("lets the start reach one step before the end of the day", () => {
+    // The end is free to run past midnight, so only the start is held back.
+    expect(clampMoveStartMinutes(26 * 60, 0, 24, 15)).toBe(24 * 60 - 15);
+    expect(clampMoveStartMinutes(23 * 60 + 45, 0, 24, 15)).toBe(23 * 60 + 45);
+  });
+
+  it("holds the start at the top of the window", () => {
+    expect(clampMoveStartMinutes(-120, 0, 24, 15)).toBe(0);
+    expect(clampMoveStartMinutes(7 * 60, 8, 18, 15)).toBe(8 * 60);
+  });
+
+  it("respects a narrowed window and the snap step", () => {
+    expect(clampMoveStartMinutes(20 * 60, 8, 18, 30)).toBe(18 * 60 - 30);
+  });
+
+  it("never inverts when the step is wider than the window", () => {
+    expect(clampMoveStartMinutes(12 * 60, 9, 10, 120)).toBe(9 * 60);
   });
 });
 

--- a/packages/core/src/utils/drag.ts
+++ b/packages/core/src/utils/drag.ts
@@ -55,6 +55,27 @@ export function snapDeltaMinutes(
   return Math.round(rawMinutes / stepMinutes) * stepMinutes;
 }
 
+/**
+ * Where a moved event may start, in minutes from midnight, given the grid's
+ * visible hour window. A move keeps its duration, so only the start is held
+ * inside the window: it can reach one `snapMinutes` step before `maxHour`, and
+ * the end is free to run past the end of the day, continuing on the following
+ * day. That keeps the event starting in the column it was dropped on (a
+ * cross-day *move* is the horizontal drag) while still allowing a range that
+ * spans midnight. Runs on the UI thread inside the drag gesture.
+ */
+export function clampMoveStartMinutes(
+  startMinutes: number,
+  minHour: number,
+  maxHour: number,
+  snapMinutes: number,
+): number {
+  "worklet";
+  const lower = minHour * 60;
+  const upper = Math.max(lower, maxHour * 60 - snapMinutes);
+  return Math.min(Math.max(startMinutes, lower), upper);
+}
+
 /** A copy of `date` shifted by `minutes` (may be negative). */
 export function shiftMinutes(date: Date, minutes: number): Date {
   const next = new Date(date);

--- a/packages/dom/src/TimeGrid.tsx
+++ b/packages/dom/src/TimeGrid.tsx
@@ -433,7 +433,10 @@ export function TimeGrid<T = unknown>({
   const slot = createSlots<TimeGridSlot>({ classNames, styles });
   const scrollRef = useRef<HTMLDivElement>(null);
   const dfns = locale ? { locale } : undefined;
-  const snapHours = dragStepMinutes / 60;
+  // Clamped like the native renderer: a zero or negative step would divide by zero
+  // in the snap below and put NaN through every drag commit.
+  const snapMinutes = Math.max(1, dragStepMinutes);
+  const snapHours = snapMinutes / 60;
 
   // The visible hour window [windowStart, windowEnd). Clamped the same way as the
   // native renderer so out-of-range props can't invert or overflow the day.
@@ -669,7 +672,7 @@ export function TimeGrid<T = unknown>({
       const raw = snap(dragOrigin.current.startHours + dHours);
       const startHours = d.continuesBefore
         ? raw
-        : clampMoveStartMinutes(raw * 60, windowStart, windowEnd, dragStepMinutes) / 60;
+        : clampMoveStartMinutes(raw * 60, windowStart, windowEnd, snapMinutes) / 60;
       // Map the horizontal drag to whole day columns, clamped so the in-view box
       // can't leave the visible range (mirrors the native renderer). Once paged,
       // the drop day comes from the hit-test instead.
@@ -921,10 +924,10 @@ export function TimeGrid<T = unknown>({
     const moved = Math.abs(endPx - o.startPx) > 4;
     const h = hourHeightRef.current;
     if (moved && onCreateEvent) {
-      const range = cellRangeFromDrag(day, o.startPx, endPx, h, windowStart, dragStepMinutes);
+      const range = cellRangeFromDrag(day, o.startPx, endPx, h, windowStart, snapMinutes);
       if (range) onCreateEvent(range.start, range.end);
     } else if (onPressCell) {
-      const at = cellRangeFromDrag(day, o.startPx, o.startPx, h, windowStart, dragStepMinutes);
+      const at = cellRangeFromDrag(day, o.startPx, o.startPx, h, windowStart, snapMinutes);
       if (at) onPressCell(at.start);
     }
     createOrigin.current = null;

--- a/packages/dom/src/TimeGrid.tsx
+++ b/packages/dom/src/TimeGrid.tsx
@@ -662,14 +662,14 @@ export function TimeGrid<T = unknown>({
     const snap = (v: number) => Math.round(v / snapHours) * snapHours;
     if (d.kind === "move") {
       // Only the start is held inside the window; the end may run past the end of
-      // the day, continuing on the next one (see `clampMoveStartMinutes`).
-      const startHours =
-        clampMoveStartMinutes(
-          snap(dragOrigin.current.startHours + dHours) * 60,
-          windowStart,
-          windowEnd,
-          dragStepMinutes,
-        ) / 60;
+      // the day, continuing on the next one (see `clampMoveStartMinutes`). A
+      // segment that continues *before* is skipped: its 00:00 top edge is where the
+      // layout clipped the event, not where the event starts, so holding it there
+      // would make the tail of a midnight-spanning event impossible to drag earlier.
+      const raw = snap(dragOrigin.current.startHours + dHours);
+      const startHours = d.continuesBefore
+        ? raw
+        : clampMoveStartMinutes(raw * 60, windowStart, windowEnd, dragStepMinutes) / 60;
       // Map the horizontal drag to whole day columns, clamped so the in-view box
       // can't leave the visible range (mirrors the native renderer). Once paged,
       // the drop day comes from the hit-test instead.

--- a/packages/dom/src/TimeGrid.tsx
+++ b/packages/dom/src/TimeGrid.tsx
@@ -42,6 +42,7 @@ import {
   isWeekend,
   layoutDayEvents,
   overlapsOtherEvents,
+  type PositionedEvent,
   useNow,
   type TimeGridMode,
   titleNumberOfLines,
@@ -801,19 +802,19 @@ export function TimeGrid<T = unknown>({
     finishDrag();
   };
 
+  // Takes the laid-out segment whole rather than five of its fields: the two
+  // `continues*` flags are the same type, so passing them positionally invites a
+  // silent transposition.
   const beginDrag = (
     e: ReactPointerEvent,
-    event: CalendarEvent<T>,
+    pe: PositionedEvent<T>,
     key: string,
     kind: "move" | "resize" | "resize-start",
-    startHours: number,
-    durationHours: number,
-    continuesBefore: boolean,
-    continuesAfter: boolean,
     dayIndex: number,
     onPress?: () => void,
   ) => {
     if (!onDragEvent) return;
+    const { event, startHours, durationHours, continuesBefore, continuesAfter } = pe;
     e.stopPropagation();
     try {
       (e.target as HTMLElement).setPointerCapture?.(e.pointerId);
@@ -1493,19 +1494,7 @@ export function TimeGrid<T = unknown>({
                       // remounting on a page change.
                       onPointerDown={
                         canMove
-                          ? (e) =>
-                              beginDrag(
-                                e,
-                                pe.event,
-                                key,
-                                "move",
-                                pe.startHours,
-                                pe.durationHours,
-                                pe.continuesBefore,
-                                pe.continuesAfter,
-                                dayIndex,
-                                onPress,
-                              )
+                          ? (e) => beginDrag(e, pe, key, "move", dayIndex, onPress)
                           : undefined
                       }
                       onClick={canMove ? undefined : onPress}
@@ -1542,17 +1531,7 @@ export function TimeGrid<T = unknown>({
                         <div
                           onPointerDown={(e) => {
                             e.stopPropagation();
-                            beginDrag(
-                              e,
-                              pe.event,
-                              key,
-                              "resize-start",
-                              pe.startHours,
-                              pe.durationHours,
-                              pe.continuesBefore,
-                              pe.continuesAfter,
-                              dayIndex,
-                            );
+                            beginDrag(e, pe, key, "resize-start", dayIndex);
                           }}
                           style={{
                             position: "absolute",
@@ -1574,17 +1553,7 @@ export function TimeGrid<T = unknown>({
                         <div
                           onPointerDown={(e) => {
                             e.stopPropagation();
-                            beginDrag(
-                              e,
-                              pe.event,
-                              key,
-                              "resize",
-                              pe.startHours,
-                              pe.durationHours,
-                              pe.continuesBefore,
-                              pe.continuesAfter,
-                              dayIndex,
-                            );
+                            beginDrag(e, pe, key, "resize", dayIndex);
                           }}
                           style={{
                             position: "absolute",

--- a/packages/dom/src/TimeGrid.tsx
+++ b/packages/dom/src/TimeGrid.tsx
@@ -1,4 +1,12 @@
-import { addDays, addMinutes, format, getISOWeek, type Locale, startOfDay } from "date-fns";
+import {
+  addDays,
+  addMinutes,
+  differenceInCalendarDays,
+  format,
+  getISOWeek,
+  type Locale,
+  startOfDay,
+} from "date-fns";
 import {
   type ComponentType,
   type CSSProperties,
@@ -17,6 +25,7 @@ import {
   type CalendarEvent,
   type CalendarMode,
   cellRangeFromDrag,
+  clampMoveStartMinutes,
   pageStepDays,
   backgroundBandsForDay,
   closedHourBands,
@@ -69,6 +78,7 @@ export type TimeGridSlot =
   | "createGhost";
 
 const GUTTER_WIDTH = 56;
+const HOURS_PER_DAY = 24;
 const clamp = (v: number, lo: number, hi: number) => Math.min(hi, Math.max(lo, v));
 
 // Edge auto-advance: how close to the day-columns edge (px) counts as "at the
@@ -249,6 +259,12 @@ type DragState = {
   dayDelta: number;
   /** Pixel equivalent of dayDelta, applied as a transform on the dragged box. */
   dayOffsetPx: number;
+  /** Whether the dragged segment already carries on into the next day. */
+  continuesAfter: boolean;
+  /** Hours of a move that run past the end of the day, previewed in the next column. */
+  spillHours: number;
+  /** Column that previews the spill, or -1 when there is none to show. */
+  spillDayIndex: number;
   moved: boolean;
 };
 
@@ -449,6 +465,12 @@ export function TimeGrid<T = unknown>({
     durationHours: number;
     dayIndex: number;
     dayWidth: number;
+    // The dragged *segment*'s bounds when the gesture began. A multi-day event is
+    // laid out as one segment per day, so the commit shifts the real event by how
+    // far its segment moved rather than rebuilding the event from the segment
+    // (which would truncate everything outside the dragged day).
+    segmentStart: Date;
+    segmentEnd: Date;
   } | null>(null);
   const applyDrag = (next: DragState | null) => {
     dragRef.current = next;
@@ -638,13 +660,15 @@ export function TimeGrid<T = unknown>({
     const dHours = (e.clientY - dragOrigin.current.pointerY) / hourHeightRef.current;
     const snap = (v: number) => Math.round(v / snapHours) * snapHours;
     if (d.kind === "move") {
-      // Guard the upper bound: an event taller than the window would otherwise
-      // invert the clamp (`windowEnd - duration < windowStart`) and teleport.
-      const startHours = clamp(
-        snap(dragOrigin.current.startHours + dHours),
-        windowStart,
-        Math.max(windowStart, windowEnd - d.durationHours),
-      );
+      // Only the start is held inside the window; the end may run past the end of
+      // the day, continuing on the next one (see `clampMoveStartMinutes`).
+      const startHours =
+        clampMoveStartMinutes(
+          snap(dragOrigin.current.startHours + dHours) * 60,
+          windowStart,
+          windowEnd,
+          dragStepMinutes,
+        ) / 60;
       // Map the horizontal drag to whole day columns, clamped so the in-view box
       // can't leave the visible range (mirrors the native renderer). Once paged,
       // the drop day comes from the hit-test instead.
@@ -652,7 +676,35 @@ export function TimeGrid<T = unknown>({
       const rawDayDelta = o.dayWidth > 0 ? Math.round((e.clientX - o.pointerX) / o.dayWidth) : 0;
       const targetDay = clamp(o.dayIndex + rawDayDelta, 0, daysRef.current.length - 1);
       const dayDelta = targetDay - o.dayIndex;
-      applyDrag({ ...d, startHours, dayDelta, dayOffsetPx: dayDelta * o.dayWidth, moved: true });
+      // Preview the part that runs past *midnight* at the top of the next column.
+      // Measured against the end of the day, not `windowEnd`: a narrowed window
+      // (say 8–18) leaves plenty of events hanging below the last visible hour
+      // without them reaching the next day at all.
+      const spillHours = Math.min(
+        Math.max(startHours + d.durationHours - HOURS_PER_DAY, 0),
+        windowHours,
+      );
+      const nextDay = daysRef.current[targetDay + 1];
+      const spillDayIndex =
+        spillHours > 0 &&
+        nextDay &&
+        // Only when that column really is the next calendar day (`hiddenDays` can
+        // break the run), otherwise the spill lands off-view and isn't shown.
+        differenceInCalendarDays(nextDay, daysRef.current[targetDay]) === 1 &&
+        // A segment that already continues after owns a real next-day box; a
+        // preview on top of it would just double up.
+        !d.continuesAfter
+          ? targetDay + 1
+          : -1;
+      applyDrag({
+        ...d,
+        startHours,
+        dayDelta,
+        dayOffsetPx: dayDelta * o.dayWidth,
+        spillHours,
+        spillDayIndex,
+        moved: true,
+      });
       // Follow the pointer with the floating ghost once the origin column is gone.
       const g = ghostRef.current;
       const held = draggedRef.current;
@@ -705,7 +757,8 @@ export function TimeGrid<T = unknown>({
       held?.onPress();
       return;
     }
-    const originIndex = dragOrigin.current?.dayIndex ?? 0;
+    const origin = dragOrigin.current;
+    const originIndex = origin?.dayIndex ?? 0;
     let base: Date | null = null;
     if (d.kind === "move") {
       if (pagedRef.current) {
@@ -723,10 +776,19 @@ export function TimeGrid<T = unknown>({
     } else {
       base = startOfDay(daysRef.current[originIndex] ?? daysRef.current[0]);
     }
-    if (base && held) {
-      const start = addMinutes(base, Math.round(d.startHours * 60));
-      const end = addMinutes(base, Math.round((d.startHours + d.durationHours) * 60));
-      onDragEventRef.current?.(held.event, start, end);
+    if (base && held && origin) {
+      // Shift the real event by how far its segment moved, so a move that now
+      // spans midnight (and every later drag of the resulting multi-day event)
+      // keeps the parts outside the dragged day instead of clipping to it.
+      const segmentStart = addMinutes(base, Math.round(d.startHours * 60));
+      const segmentEnd = addMinutes(base, Math.round((d.startHours + d.durationHours) * 60));
+      const startShift =
+        d.kind === "resize" ? 0 : segmentStart.getTime() - origin.segmentStart.getTime();
+      const endShift =
+        d.kind === "resize-start" ? 0 : segmentEnd.getTime() - origin.segmentEnd.getTime();
+      const start = new Date(held.event.start.getTime() + startShift);
+      const end = new Date(held.event.end.getTime() + endShift);
+      if (end > start) onDragEventRef.current?.(held.event, start, end);
     }
     finishDrag();
   };
@@ -742,6 +804,7 @@ export function TimeGrid<T = unknown>({
     kind: "move" | "resize" | "resize-start",
     startHours: number,
     durationHours: number,
+    continuesAfter: boolean,
     dayIndex: number,
     onPress?: () => void,
   ) => {
@@ -759,6 +822,7 @@ export function TimeGrid<T = unknown>({
     const column = kind === "move" ? boxEl.parentElement : null;
     const dayWidth = column ? column.getBoundingClientRect().width : 0;
     const boxRect = kind === "move" ? boxEl.getBoundingClientRect() : null;
+    const originBase = startOfDay(days[dayIndex] ?? days[0]);
     dragOrigin.current = {
       pointerX: e.clientX,
       pointerY: e.clientY,
@@ -766,6 +830,8 @@ export function TimeGrid<T = unknown>({
       durationHours,
       dayIndex,
       dayWidth,
+      segmentStart: addMinutes(originBase, Math.round(startHours * 60)),
+      segmentEnd: addMinutes(originBase, Math.round((startHours + durationHours) * 60)),
     };
     draggedRef.current = {
       event,
@@ -780,7 +846,18 @@ export function TimeGrid<T = unknown>({
     pagedRef.current = false;
     setPaged(false);
     clearEdgeTimer();
-    applyDrag({ key, kind, startHours, durationHours, dayDelta: 0, dayOffsetPx: 0, moved: false });
+    applyDrag({
+      key,
+      kind,
+      startHours,
+      durationHours,
+      continuesAfter,
+      dayDelta: 0,
+      dayOffsetPx: 0,
+      spillHours: 0,
+      spillDayIndex: -1,
+      moved: false,
+    });
     onDragStart?.(event);
     // Transport the rest of the drag at the document level so it survives the day
     // columns unmounting on a page change (the dragged box's own node disappears).
@@ -864,6 +941,26 @@ export function TimeGrid<T = unknown>({
     () => days.map((day) => layoutDayEvents(events, day)),
     [days, events],
   );
+
+  // The tail of an in-progress move that runs past midnight, shown on `dayIndex`
+  // so the drop is visible on both days at once. `drag` and `draggedRef` are set
+  // together in `beginDrag` and cleared together in `finishDrag`, so the guard on
+  // the state keeps the ref read consistent.
+  const spillPreviewFor = (dayIndex: number): DomRenderEventArgs<T> | null => {
+    if (paged || !drag || drag.kind !== "move" || drag.spillDayIndex !== dayIndex) return null;
+    const dragged = draggedRef.current?.event;
+    if (!dragged) return null;
+    return {
+      event: dragged,
+      mode,
+      isAllDay: false,
+      boxHeight: Math.max(drag.spillHours * hourHeight, 14),
+      continuesBefore: true,
+      continuesAfter: false,
+      ampm,
+      onPress: () => {},
+    };
+  };
 
   // Arrow-key navigation across events (`keyboardEventNavigation`). This is purely
   // additive: every event stays a tab stop (so screen-reader users keep full
@@ -1234,6 +1331,10 @@ export function TimeGrid<T = unknown>({
             const nowTop = (nowHours - windowStart) * hourHeight;
             const bands = bandsByDay[dayIndex];
             const ghost = createBox?.dayIndex === dayIndex ? createBox : null;
+            // The tail of a move that runs past midnight, previewed at the top of
+            // this column. The dragged event is looked up from its `drag.key`
+            // ("<originColumn>:<index>"), so no extra state has to track it.
+            const spill = spillPreviewFor(dayIndex);
             return (
               <div
                 key={day.toISOString()}
@@ -1326,7 +1427,14 @@ export function TimeGrid<T = unknown>({
                   )
                     return null;
                   const top = (startHours - windowStart) * hourHeight;
-                  const boxHeight = Math.max(durationHours * hourHeight, 14);
+                  // A drag that runs past midnight is cut off at the day boundary
+                  // (a move previews the remainder in the next column). Applied to
+                  // resting boxes too, where `layoutDayEvents` has already clipped
+                  // them to the day, so the height doesn't jump on commit.
+                  const boxHeight = Math.max(
+                    Math.min(durationHours, HOURS_PER_DAY - startHours) * hourHeight,
+                    14,
+                  );
                   const widthPct = 100 / pe.columns;
                   const onPress = () => onPressEvent?.(pe.event);
                   const args: DomRenderEventArgs<T> = {
@@ -1387,6 +1495,7 @@ export function TimeGrid<T = unknown>({
                                 "move",
                                 pe.startHours,
                                 pe.durationHours,
+                                pe.continuesAfter,
                                 dayIndex,
                                 onPress,
                               )
@@ -1433,6 +1542,7 @@ export function TimeGrid<T = unknown>({
                               "resize-start",
                               pe.startHours,
                               pe.durationHours,
+                              pe.continuesAfter,
                               dayIndex,
                             );
                           }}
@@ -1458,6 +1568,7 @@ export function TimeGrid<T = unknown>({
                               "resize",
                               pe.startHours,
                               pe.durationHours,
+                              pe.continuesAfter,
                               dayIndex,
                             );
                           }}
@@ -1475,6 +1586,34 @@ export function TimeGrid<T = unknown>({
                     </div>
                   );
                 })}
+                {spill ? (
+                  <div
+                    aria-hidden
+                    {...dataState({ "data-dragging": true })}
+                    {...slot("event", {
+                      base: {
+                        position: "absolute",
+                        // Anchored at midnight, which sits `windowStart` hours above
+                        // the top of the grid. With a window that starts after 00:00
+                        // the preview is scrolled out of view, exactly like the
+                        // continuation the drop will commit.
+                        top: -windowStart * hourHeight,
+                        left: 1,
+                        right: 1,
+                        height: spill.boxHeight,
+                        pointerEvents: "none",
+                        zIndex: 3,
+                        opacity: 0.85,
+                      },
+                    })}
+                  >
+                    {Renderer ? (
+                      <Renderer {...spill} />
+                    ) : (
+                      <DefaultDomEvent {...spill} theme={theme} boxProps={slot("eventBox")} />
+                    )}
+                  </div>
+                ) : null}
                 {showNow ? (
                   <div
                     {...slot("nowIndicator", {

--- a/packages/dom/src/TimeGrid.tsx
+++ b/packages/dom/src/TimeGrid.tsx
@@ -259,7 +259,8 @@ type DragState = {
   dayDelta: number;
   /** Pixel equivalent of dayDelta, applied as a transform on the dragged box. */
   dayOffsetPx: number;
-  /** Whether the dragged segment already carries on into the next day. */
+  /** Whether the dragged segment carries on from the previous day / into the next. */
+  continuesBefore: boolean;
   continuesAfter: boolean;
   /** Hours of a move that run past the end of the day, previewed in the next column. */
   spillHours: number;
@@ -804,6 +805,7 @@ export function TimeGrid<T = unknown>({
     kind: "move" | "resize" | "resize-start",
     startHours: number,
     durationHours: number,
+    continuesBefore: boolean,
     continuesAfter: boolean,
     dayIndex: number,
     onPress?: () => void,
@@ -851,6 +853,7 @@ export function TimeGrid<T = unknown>({
       kind,
       startHours,
       durationHours,
+      continuesBefore,
       continuesAfter,
       dayDelta: 0,
       dayOffsetPx: 0,
@@ -1495,6 +1498,7 @@ export function TimeGrid<T = unknown>({
                                 "move",
                                 pe.startHours,
                                 pe.durationHours,
+                                pe.continuesBefore,
                                 pe.continuesAfter,
                                 dayIndex,
                                 onPress,
@@ -1542,6 +1546,7 @@ export function TimeGrid<T = unknown>({
                               "resize-start",
                               pe.startHours,
                               pe.durationHours,
+                              pe.continuesBefore,
                               pe.continuesAfter,
                               dayIndex,
                             );
@@ -1557,7 +1562,12 @@ export function TimeGrid<T = unknown>({
                           }}
                         />
                       ) : null}
-                      {canResize ? (
+                      {/* Only the segment that owns the real end may be resized
+                          from the bottom (matching the native renderer). On a
+                          continued segment the bottom edge is the day boundary,
+                          not the event's end, so dragging it would move an end
+                          the user can't see. */}
+                      {canResize && !pe.continuesAfter ? (
                         <div
                           onPointerDown={(e) => {
                             e.stopPropagation();
@@ -1568,6 +1578,7 @@ export function TimeGrid<T = unknown>({
                               "resize",
                               pe.startHours,
                               pe.durationHours,
+                              pe.continuesBefore,
                               pe.continuesAfter,
                               dayIndex,
                             );

--- a/packages/dom/src/__tests__/TimeGrid.test.tsx
+++ b/packages/dom/src/__tests__/TimeGrid.test.tsx
@@ -233,6 +233,168 @@ describe("dom TimeGrid", () => {
     expect(end.getHours()).toBe(16);
   });
 
+  it("drag-moves an event past the end of the day, continuing it on the next one", () => {
+    const onDragEvent = jest.fn();
+    const late: CalendarEvent[] = [
+      { title: "Gig", start: new Date(2026, 5, 26, 19, 0), end: new Date(2026, 5, 26, 23, 0) },
+    ];
+    const { getByText } = render(
+      <TimeGrid date={day} mode="week" events={late} hourHeight={48} onDragEvent={onDragEvent} />,
+    );
+    const box = wrapperOf(getByText("Gig"));
+    // Down 96px = 2h at 48px/hour: 19:00–23:00 -> 21:00 on the 26th to 01:00 on
+    // the 27th. The end is free to run past midnight; only the start is held in
+    // the day it was dropped on.
+    fireEvent.pointerDown(box, { clientY: 300, pointerId: 1 });
+    fireEvent.pointerMove(box, { clientY: 396, pointerId: 1 });
+    fireEvent.pointerUp(box, { clientY: 396, pointerId: 1 });
+
+    expect(onDragEvent).toHaveBeenCalledTimes(1);
+    const [, start, end] = onDragEvent.mock.calls[0] as [CalendarEvent, Date, Date];
+    expect([start.getDate(), start.getHours()]).toEqual([26, 21]);
+    expect([end.getDate(), end.getHours()]).toEqual([27, 1]);
+  });
+
+  it("holds a moved start inside the day, one snap step before its end", () => {
+    const onDragEvent = jest.fn();
+    const late: CalendarEvent[] = [
+      { title: "Gig", start: new Date(2026, 5, 26, 19, 0), end: new Date(2026, 5, 26, 23, 0) },
+    ];
+    const { getByText } = render(
+      <TimeGrid date={day} mode="week" events={late} hourHeight={48} onDragEvent={onDragEvent} />,
+    );
+    const box = wrapperOf(getByText("Gig"));
+    // Far past the bottom of the grid: the start stops at 23:45 (24:00 less one
+    // 15-minute step) rather than rolling the whole event onto the next day.
+    fireEvent.pointerDown(box, { clientY: 300, pointerId: 1 });
+    fireEvent.pointerMove(box, { clientY: 1500, pointerId: 1 });
+    fireEvent.pointerUp(box, { clientY: 1500, pointerId: 1 });
+
+    const [, start, end] = onDragEvent.mock.calls[0] as [CalendarEvent, Date, Date];
+    expect([start.getDate(), start.getHours(), start.getMinutes()]).toEqual([26, 23, 45]);
+    expect([end.getDate(), end.getHours(), end.getMinutes()]).toEqual([27, 3, 45]);
+  });
+
+  it("does not preview a next-day spill for an event that only leaves the visible window", () => {
+    const onDragEvent = jest.fn();
+    // The window ends at 18:00, so this event already runs past the bottom of the
+    // grid without touching midnight. Moving it must not claim it spills.
+    const late: CalendarEvent[] = [
+      { title: "Shift", start: new Date(2026, 5, 26, 15, 0), end: new Date(2026, 5, 26, 19, 0) },
+    ];
+    const { getByText, container } = render(
+      <TimeGrid
+        date={day}
+        mode="week"
+        events={late}
+        hourHeight={48}
+        minHour={8}
+        maxHour={18}
+        onDragEvent={onDragEvent}
+      />,
+    );
+    const box = wrapperOf(getByText("Shift"));
+    fireEvent.pointerDown(box, { clientY: 300, pointerId: 1 });
+    fireEvent.pointerMove(box, { clientY: 348, pointerId: 1 });
+    expect(container.querySelectorAll("[data-dragging]")).toHaveLength(1);
+    fireEvent.pointerUp(box, { clientY: 348, pointerId: 1 });
+
+    const [, start, end] = onDragEvent.mock.calls[0] as [CalendarEvent, Date, Date];
+    expect([start.getDate(), start.getHours()]).toEqual([26, 16]);
+    expect([end.getDate(), end.getHours()]).toEqual([26, 20]);
+  });
+
+  it("anchors the next-day preview at midnight, not at the top of the visible window", () => {
+    const late: CalendarEvent[] = [
+      { title: "Gig", start: new Date(2026, 5, 26, 22, 0), end: new Date(2026, 5, 26, 23, 0) },
+    ];
+    const { getByText, container } = render(
+      <TimeGrid
+        date={day}
+        mode="week"
+        events={late}
+        hourHeight={48}
+        minHour={8}
+        onDragEvent={jest.fn()}
+      />,
+    );
+    const box = wrapperOf(getByText("Gig"));
+    // Down 96px = 2h: 22:00–23:00 -> 00:00–01:00 on the 27th. The tail belongs at
+    // midnight, which is 8 hours (384px) above the 08:00 top of this grid.
+    fireEvent.pointerDown(box, { clientY: 300, pointerId: 1 });
+    fireEvent.pointerMove(box, { clientY: 396, pointerId: 1 });
+    const preview = [...container.querySelectorAll("[data-dragging]")].find((el) =>
+      el.hasAttribute("aria-hidden"),
+    ) as HTMLElement;
+    expect(preview.style.top).toBe("-384px");
+    fireEvent.pointerUp(box, { clientY: 396, pointerId: 1 });
+  });
+
+  it("keeps a multi-day event whole when one of its day segments is dragged", () => {
+    const onDragEvent = jest.fn();
+    const trip: CalendarEvent[] = [
+      { title: "Trip", start: new Date(2026, 5, 24, 17, 0), end: new Date(2026, 5, 26, 21, 0) },
+    ];
+    const { getAllByText } = render(
+      <TimeGrid date={day} mode="week" events={trip} hourHeight={48} onDragEvent={onDragEvent} />,
+    );
+    // The middle segment (the 25th) owns neither the real start nor the real end.
+    const box = wrapperOf(getAllByText("Trip")[1]);
+    fireEvent.pointerDown(box, { clientY: 300, pointerId: 1 });
+    fireEvent.pointerMove(box, { clientY: 348, pointerId: 1 });
+    fireEvent.pointerUp(box, { clientY: 348, pointerId: 1 });
+
+    expect(onDragEvent).toHaveBeenCalledTimes(1);
+    const [, start, end] = onDragEvent.mock.calls[0] as [CalendarEvent, Date, Date];
+    // The whole event slides an hour later; the days outside the dragged
+    // segment survive instead of being clipped to it.
+    expect([start.getDate(), start.getHours()]).toEqual([24, 18]);
+    expect([end.getDate(), end.getHours()]).toEqual([26, 22]);
+  });
+
+  it("keeps a multi-day event's later days when a continued segment is resized", () => {
+    const onDragEvent = jest.fn();
+    const trip: CalendarEvent[] = [
+      { title: "Trip", start: new Date(2026, 5, 24, 22, 0), end: new Date(2026, 5, 26, 10, 0) },
+    ];
+    const { getAllByText } = render(
+      <TimeGrid date={day} mode="week" events={trip} hourHeight={48} onDragEvent={onDragEvent} />,
+    );
+    // The 24th's segment runs 22:00–24:00 and continues after, so its bottom grip
+    // moves the event's real end on the 26th, not the day boundary it's drawn at.
+    const box = wrapperOf(getAllByText("Trip")[0]);
+    const grip = Array.from(box.querySelectorAll<HTMLElement>('div[style*="ns-resize"]')).find(
+      (el) => el.style.bottom === "0px",
+    )!;
+    fireEvent.pointerDown(grip, { clientY: 300, pointerId: 1 });
+    fireEvent.pointerMove(grip, { clientY: 252, pointerId: 1 });
+    fireEvent.pointerUp(grip, { clientY: 252, pointerId: 1 });
+
+    const [, start, end] = onDragEvent.mock.calls[0] as [CalendarEvent, Date, Date];
+    expect([start.getDate(), start.getHours()]).toEqual([24, 22]);
+    expect([end.getDate(), end.getHours()]).toEqual([26, 9]);
+  });
+
+  it("preserves a sub-step event's duration through a drag", () => {
+    const onDragEvent = jest.fn();
+    // Shorter than the layout's minimum box, so it is drawn as 15 minutes. The
+    // commit must move it, not stretch it to what it was drawn as.
+    const tiny: CalendarEvent[] = [
+      { title: "Ping", start: new Date(2026, 5, 26, 9, 0), end: new Date(2026, 5, 26, 9, 5) },
+    ];
+    const { getByText } = render(
+      <TimeGrid date={day} mode="day" events={tiny} hourHeight={48} onDragEvent={onDragEvent} />,
+    );
+    const box = wrapperOf(getByText("Ping"));
+    fireEvent.pointerDown(box, { clientY: 300, pointerId: 1 });
+    fireEvent.pointerMove(box, { clientY: 324, pointerId: 1 });
+    fireEvent.pointerUp(box, { clientY: 324, pointerId: 1 });
+
+    const [, start, end] = onDragEvent.mock.calls[0] as [CalendarEvent, Date, Date];
+    expect([start.getHours(), start.getMinutes()]).toEqual([9, 30]);
+    expect([end.getHours(), end.getMinutes()]).toEqual([9, 35]);
+  });
+
   it("clamps a cross-day drag to the edges of the visible week", () => {
     const onDragEvent = jest.fn();
     const { getByText } = render(

--- a/packages/dom/src/__tests__/TimeGrid.test.tsx
+++ b/packages/dom/src/__tests__/TimeGrid.test.tsx
@@ -352,47 +352,23 @@ describe("dom TimeGrid", () => {
     expect([end.getDate(), end.getHours()]).toEqual([26, 22]);
   });
 
-  it("keeps a multi-day event's later days when a continued segment is resized", () => {
-    const onDragEvent = jest.fn();
+  it("offers the bottom resize grip only on the segment that owns the event's end", () => {
     const trip: CalendarEvent[] = [
       { title: "Trip", start: new Date(2026, 5, 24, 22, 0), end: new Date(2026, 5, 26, 10, 0) },
     ];
     const { getAllByText } = render(
-      <TimeGrid date={day} mode="week" events={trip} hourHeight={48} onDragEvent={onDragEvent} />,
+      <TimeGrid date={day} mode="week" events={trip} hourHeight={48} onDragEvent={jest.fn()} />,
     );
-    // The 24th's segment runs 22:00–24:00 and continues after, so its bottom grip
-    // moves the event's real end on the 26th, not the day boundary it's drawn at.
-    const box = wrapperOf(getAllByText("Trip")[0]);
-    const grip = Array.from(box.querySelectorAll<HTMLElement>('div[style*="ns-resize"]')).find(
-      (el) => el.style.bottom === "0px",
-    )!;
-    fireEvent.pointerDown(grip, { clientY: 300, pointerId: 1 });
-    fireEvent.pointerMove(grip, { clientY: 252, pointerId: 1 });
-    fireEvent.pointerUp(grip, { clientY: 252, pointerId: 1 });
-
-    const [, start, end] = onDragEvent.mock.calls[0] as [CalendarEvent, Date, Date];
-    expect([start.getDate(), start.getHours()]).toEqual([24, 22]);
-    expect([end.getDate(), end.getHours()]).toEqual([26, 9]);
-  });
-
-  it("preserves a sub-step event's duration through a drag", () => {
-    const onDragEvent = jest.fn();
-    // Shorter than the layout's minimum box, so it is drawn as 15 minutes. The
-    // commit must move it, not stretch it to what it was drawn as.
-    const tiny: CalendarEvent[] = [
-      { title: "Ping", start: new Date(2026, 5, 26, 9, 0), end: new Date(2026, 5, 26, 9, 5) },
-    ];
-    const { getByText } = render(
-      <TimeGrid date={day} mode="day" events={tiny} hourHeight={48} onDragEvent={onDragEvent} />,
-    );
-    const box = wrapperOf(getByText("Ping"));
-    fireEvent.pointerDown(box, { clientY: 300, pointerId: 1 });
-    fireEvent.pointerMove(box, { clientY: 324, pointerId: 1 });
-    fireEvent.pointerUp(box, { clientY: 324, pointerId: 1 });
-
-    const [, start, end] = onDragEvent.mock.calls[0] as [CalendarEvent, Date, Date];
-    expect([start.getHours(), start.getMinutes()]).toEqual([9, 30]);
-    expect([end.getHours(), end.getMinutes()]).toEqual([9, 35]);
+    const bottomGrip = (box: HTMLElement) =>
+      Array.from(box.querySelectorAll<HTMLElement>('div[style*="ns-resize"]')).filter(
+        (el) => el.style.bottom === "0px",
+      );
+    // The 24th's and 25th's segments end at the day boundary, not at the event's
+    // end, so dragging their bottom edge would move an end the user can't see.
+    expect(bottomGrip(wrapperOf(getAllByText("Trip")[0]))).toHaveLength(0);
+    expect(bottomGrip(wrapperOf(getAllByText("Trip")[1]))).toHaveLength(0);
+    // The 26th's segment owns the real end and keeps its grip.
+    expect(bottomGrip(wrapperOf(getAllByText("Trip")[2]))).toHaveLength(1);
   });
 
   it("clamps a cross-day drag to the edges of the visible week", () => {

--- a/packages/dom/src/__tests__/TimeGrid.test.tsx
+++ b/packages/dom/src/__tests__/TimeGrid.test.tsx
@@ -371,6 +371,55 @@ describe("dom TimeGrid", () => {
     expect(bottomGrip(wrapperOf(getAllByText("Trip")[2]))).toHaveLength(1);
   });
 
+  it("drags the tail of a midnight-spanning event earlier, moving the whole event", () => {
+    const onDragEvent = jest.fn();
+    // 22:00 on the 26th to 02:00 on the 27th, so the 27th's segment is a 00:00
+    // continuation: its top edge is where the layout clipped it, not the start.
+    const overnight: CalendarEvent[] = [
+      { title: "Night", start: new Date(2026, 5, 26, 22, 0), end: new Date(2026, 5, 27, 2, 0) },
+    ];
+    const { getAllByText } = render(
+      <TimeGrid
+        date={day}
+        mode="week"
+        events={overnight}
+        hourHeight={48}
+        onDragEvent={onDragEvent}
+      />,
+    );
+    const tail = wrapperOf(getAllByText("Night")[1]);
+    // Up 48px = 1h. Held at 00:00 the drag would be a no-op; the whole event
+    // must shift an hour earlier instead.
+    fireEvent.pointerDown(tail, { clientY: 300, pointerId: 1 });
+    fireEvent.pointerMove(tail, { clientY: 252, pointerId: 1 });
+    fireEvent.pointerUp(tail, { clientY: 252, pointerId: 1 });
+
+    expect(onDragEvent).toHaveBeenCalledTimes(1);
+    const [, start, end] = onDragEvent.mock.calls[0] as [CalendarEvent, Date, Date];
+    expect([start.getDate(), start.getHours()]).toEqual([26, 21]);
+    expect([end.getDate(), end.getHours()]).toEqual([27, 1]);
+  });
+
+  it("preserves a sub-step event's duration through a drag", () => {
+    const onDragEvent = jest.fn();
+    // Shorter than the layout's minimum box, so it is drawn as 15 minutes. The
+    // commit must move it, not stretch it to what it was drawn as.
+    const tiny: CalendarEvent[] = [
+      { title: "Ping", start: new Date(2026, 5, 26, 9, 0), end: new Date(2026, 5, 26, 9, 5) },
+    ];
+    const { getByText } = render(
+      <TimeGrid date={day} mode="day" events={tiny} hourHeight={48} onDragEvent={onDragEvent} />,
+    );
+    const box = wrapperOf(getByText("Ping"));
+    fireEvent.pointerDown(box, { clientY: 300, pointerId: 1 });
+    fireEvent.pointerMove(box, { clientY: 324, pointerId: 1 });
+    fireEvent.pointerUp(box, { clientY: 324, pointerId: 1 });
+
+    const [, start, end] = onDragEvent.mock.calls[0] as [CalendarEvent, Date, Date];
+    expect([start.getHours(), start.getMinutes()]).toEqual([9, 30]);
+    expect([end.getHours(), end.getMinutes()]).toEqual([9, 35]);
+  });
+
   it("clamps a cross-day drag to the edges of the visible week", () => {
     const onDragEvent = jest.fn();
     const { getByText } = render(

--- a/packages/dom/src/__tests__/TimeGrid.test.tsx
+++ b/packages/dom/src/__tests__/TimeGrid.test.tsx
@@ -420,6 +420,30 @@ describe("dom TimeGrid", () => {
     expect([end.getHours(), end.getMinutes()]).toEqual([9, 35]);
   });
 
+  it("survives a zero dragStepMinutes instead of committing an invalid date", () => {
+    const onDragEvent = jest.fn();
+    const { getByText } = render(
+      <TimeGrid
+        date={day}
+        mode="day"
+        events={events}
+        hourHeight={48}
+        dragStepMinutes={0}
+        onDragEvent={onDragEvent}
+      />,
+    );
+    const box = wrapperOf(getByText("Focus"));
+    // A zero step would divide by zero in the snap and put NaN through the whole
+    // commit; it falls back to a one-minute step, as on the native renderer.
+    fireEvent.pointerDown(box, { clientY: 300, pointerId: 1 });
+    fireEvent.pointerMove(box, { clientY: 348, pointerId: 1 });
+    fireEvent.pointerUp(box, { clientY: 348, pointerId: 1 });
+
+    const [, start, end] = onDragEvent.mock.calls[0] as [CalendarEvent, Date, Date];
+    expect(Number.isNaN(start.getTime())).toBe(false);
+    expect([start.getHours(), end.getHours()]).toEqual([15, 17]);
+  });
+
   it("clamps a cross-day drag to the edges of the visible week", () => {
     const onDragEvent = jest.fn();
     const { getByText } = render(

--- a/packages/native/src/components/TimeGrid.tsx
+++ b/packages/native/src/components/TimeGrid.tsx
@@ -441,6 +441,7 @@ function AnimatedEventBox<T>({
   // ("Cannot copy value of type `Date`").
   const startHours = positioned.startHours;
   const durationHours = positioned.durationHours;
+  const ownsStart = !positioned.continuesBefore;
   // Where the move gesture clamps from, mirrored into a shared value so it isn't a
   // gesture dependency. A gesture memoized on a value the dragged event carries
   // would be rebuilt under the finger, and so torn down mid-drag, the moment a
@@ -450,9 +451,9 @@ function AnimatedEventBox<T>({
   const dragStartSV = useDerivedValue(
     () => ({
       minutes: startHours * MINUTES_PER_HOUR,
-      ownsStart: !positioned.continuesBefore,
+      ownsStart,
     }),
-    [startHours, positioned.continuesBefore],
+    [startHours, ownsStart],
   );
 
   // Live pixel height of the box, driven on the UI thread by the shared
@@ -468,6 +469,17 @@ function AnimatedEventBox<T>({
     [durationHours],
   );
 
+  // The source segment may stop at midnight while the full event continues in
+  // the next column. Keep the height passed to custom renderers identical to the
+  // wrapper they fill, while `boxHeight` retains the complete duration for drag
+  // math and the floating cross-page ghost.
+  const visibleBoxHeight = useDerivedValue(() => {
+    const top =
+      (startHours - minHour) * cellHeight.value + moveOffset.value + resizeStartDelta.value;
+    const dayEnd = (HOURS_PER_DAY - minHour) * cellHeight.value;
+    return Math.max(Math.min(boxHeight.value, dayEnd - top), MIN_EVENT_HEIGHT);
+  }, [startHours, minHour]);
+
   const boxStyle = useAnimatedStyle(() => {
     // A top-edge resize pushes the box down and shortens it (start moves later).
     const top =
@@ -477,14 +489,13 @@ function AnimatedEventBox<T>({
     // already renders. Purely geometric, so a resting box (already clipped to the
     // day by `layoutDayEvents`) is untouched and the height doesn't jump when a
     // drag commits.
-    const dayEnd = (HOURS_PER_DAY - minHour) * cellHeight.value;
     return {
       top,
-      height: Math.max(Math.min(boxHeight.value, dayEnd - top), MIN_EVENT_HEIGHT),
+      height: visibleBoxHeight.value,
       transform: [{ translateX: moveOffsetX.value }],
       zIndex: dragZ.value,
     };
-  }, [startHours, durationHours, minHour]);
+  }, [startHours, minHour]);
 
   // Pixel height of the part of a move that runs past midnight, or 0 when nothing
   // spills. Measured against the end of the day, not `maxHour`: a narrowed window
@@ -939,7 +950,7 @@ function AnimatedEventBox<T>({
       <RenderEventComponent
         event={positioned.event}
         mode={mode}
-        boxHeight={boxHeight}
+        boxHeight={visibleBoxHeight}
         continuesBefore={positioned.continuesBefore}
         continuesAfter={positioned.continuesAfter}
         accessibilityActions={accessibilityActions}

--- a/packages/native/src/components/TimeGrid.tsx
+++ b/packages/native/src/components/TimeGrid.tsx
@@ -524,7 +524,9 @@ function AnimatedEventBox<T>({
   useAnimatedReaction(
     () => spillHeight.value > 0,
     (spilling, previous) => {
-      if (spilling !== previous) runOnJS(setPreviewMounted)(spilling);
+      // `previous` is null on the reaction's first run, which would otherwise cost
+      // every box on every page a thread hop to set the state it already has.
+      if (previous !== null && spilling !== previous) runOnJS(setPreviewMounted)(spilling);
     },
   );
 

--- a/packages/native/src/components/TimeGrid.tsx
+++ b/packages/native/src/components/TimeGrid.tsx
@@ -73,6 +73,7 @@ import {
 import {
   backgroundBandsForDay,
   cellRangeFromDrag,
+  clampMoveStartMinutes,
   useNow,
   closedHourBands,
   overlapsOtherEvents,
@@ -83,7 +84,12 @@ import {
 import { formatHour, layoutDayEvents, type PositionedEvent } from "@super-calendar/core";
 import type { EventAccessibilityLabeler } from "@super-calendar/core";
 import { type WeekdayFormat, weekdayFormatToken } from "@super-calendar/core";
-import { SlotStylesProvider, type SlotStyleProps, useSlots } from "../utils/slots";
+import {
+  type ResolvedSlot,
+  SlotStylesProvider,
+  type SlotStyleProps,
+  useSlots,
+} from "../utils/slots";
 import { useWebGridZoom } from "../utils/useWebGridZoom";
 import { useWebPagerKeys } from "../utils/useWebPagerKeys";
 import { withEventAccessibilityLabel } from "../utils/withEventAccessibilityLabel";
@@ -181,6 +187,78 @@ const EdgePagingContext = createContext<EdgePaging | null>(null);
 const noop = () => {};
 
 /**
+ * The tail of a move that runs past midnight, drawn at the top of the next day's
+ * column so the drop reads on both days before the finger lifts. Mounted only
+ * while a drag is actually spilling (see `spillHeight`), so an idle grid pays
+ * nothing for it; its geometry is driven on the UI thread from there.
+ */
+function MoveSpillPreview<T>({
+  spillHeight,
+  moveOffsetX,
+  cellHeight,
+  dayLeftPx,
+  dayWidth,
+  nextDayDirection,
+  minHour,
+  event,
+  mode,
+  renderEvent,
+  slotProps,
+}: {
+  spillHeight: SharedValue<number>;
+  moveOffsetX: SharedValue<number>;
+  cellHeight: SharedValue<number>;
+  dayLeftPx: number;
+  dayWidth: number;
+  nextDayDirection: number;
+  minHour: number;
+  event: CalendarEvent<T>;
+  mode: CalendarMode;
+  renderEvent: RenderEvent<T>;
+  slotProps: ResolvedSlot<ViewStyle>;
+}): ReactElement {
+  const RenderEventComponent = renderEvent;
+  const style = useAnimatedStyle(
+    () => ({
+      height: spillHeight.value,
+      opacity: spillHeight.value > 0 ? 1 : 0,
+      zIndex: spillHeight.value > 0 ? DRAG_EVENT_Z : 0,
+      transform: [
+        { translateX: moveOffsetX.value + nextDayDirection * dayWidth },
+        // The box's `top` is the `minHour` gridline, but the tail starts at
+        // midnight. With a window that starts after 00:00 this pushes the preview
+        // out of view, exactly like the continuation the drop will commit.
+        { translateY: -minHour * cellHeight.value },
+      ],
+    }),
+    [dayWidth, nextDayDirection, minHour],
+  );
+  return (
+    <Animated.View
+      {...slotProps}
+      accessibilityElementsHidden
+      importantForAccessibility="no-hide-descendants"
+      style={[
+        styles.eventBox,
+        styles.nonInteractive,
+        { left: dayLeftPx, width: dayWidth, top: 0 },
+        slotProps.style,
+        style,
+      ]}
+    >
+      <RenderEventComponent
+        event={event}
+        mode={mode}
+        boxHeight={spillHeight}
+        continuesBefore
+        continuesAfter={false}
+        onPress={noop}
+      />
+    </Animated.View>
+  );
+}
+
+/**
  * The floating copy of a dragged event, rendered above the pager so a cross-week
  * drag stays visible after its source page pages away. Position, size, and
  * visibility are driven on the UI thread by the shared values so it tracks the
@@ -245,8 +323,14 @@ type AnimatedEventBoxProps<T> = {
   positioned: PositionedEvent<T>;
   cellHeight: SharedValue<number>;
   minHour: number;
+  maxHour: number;
   left: number;
   width: number;
+  // Left edge of the whole day column (the box's own `left` is inset by its
+  // overlap column), so the "runs past midnight" preview can span the next column.
+  dayLeftPx: number;
+  // Which way the next calendar day lies, in columns: +1 normally, -1 under RTL.
+  nextDayDirection: number;
   // Drag-to-move across days needs the column width and this box's day index
   // within the visible range, so a horizontal drag maps to (and clamps to) days.
   dayWidth: number;
@@ -280,8 +364,11 @@ function AnimatedEventBox<T>({
   positioned,
   cellHeight,
   minHour,
+  maxHour,
   left,
   width,
+  dayLeftPx,
+  nextDayDirection,
   dayWidth,
   dayIndex,
   dayCount,
@@ -342,6 +429,10 @@ function AnimatedEventBox<T>({
   // Raised to DRAG_EVENT_Z while a gesture is active so the dragged event floats
   // above all the others, then back to 0 when it settles.
   const dragZ = useSharedValue(0);
+  // 1 while a move gesture is running. Only gates the spill preview: the box's own
+  // clip is geometric, so it can't disagree with the box during the frames between
+  // release and the committed re-render.
+  const moving = useSharedValue(0);
   // Edge auto-advance: which side the drag has pushed past the visible columns
   // (-1 left / 0 none / +1 right).
   const edgeDir = useSharedValue(0);
@@ -361,6 +452,12 @@ function AnimatedEventBox<T>({
   // ("Cannot copy value of type `Date`").
   const startHours = positioned.startHours;
   const durationHours = positioned.durationHours;
+  // Mirrored into a shared value so the move gesture can clamp against the
+  // segment's start without listing it as a dependency. A gesture memoized on a
+  // value the dragged event carries would be rebuilt under the finger, and so torn
+  // down mid-drag, the moment a consumer updates `events` (the same reason
+  // `commitDrag` reads the event through `latest`).
+  const startMinutesSV = useDerivedValue(() => startHours * MINUTES_PER_HOUR, [startHours]);
 
   // Live pixel height of the box, driven on the UI thread by the shared
   // cellHeight (plus any in-progress resize). Handed to renderEvent so custom
@@ -375,15 +472,64 @@ function AnimatedEventBox<T>({
     [durationHours],
   );
 
-  const boxStyle = useAnimatedStyle(
-    () => ({
-      // A top-edge resize pushes the box down and shortens it (start moves later).
-      top: (startHours - minHour) * cellHeight.value + moveOffset.value + resizeStartDelta.value,
-      height: boxHeight.value,
+  const boxStyle = useAnimatedStyle(() => {
+    // A top-edge resize pushes the box down and shortens it (start moves later).
+    const top =
+      (startHours - minHour) * cellHeight.value + moveOffset.value + resizeStartDelta.value;
+    // Cut the box off at midnight; whatever runs past it shows in the next column
+    // instead (see MoveSpillPreview), the way a committed event spanning midnight
+    // already renders. Purely geometric, so a resting box (already clipped to the
+    // day by `layoutDayEvents`) is untouched and the height doesn't jump when a
+    // drag commits.
+    const dayEnd = (HOURS_PER_DAY - minHour) * cellHeight.value;
+    return {
+      top,
+      height: Math.max(Math.min(boxHeight.value, dayEnd - top), MIN_EVENT_HEIGHT),
       transform: [{ translateX: moveOffsetX.value }],
       zIndex: dragZ.value,
-    }),
-    [startHours, durationHours, minHour],
+    };
+  }, [startHours, durationHours, minHour]);
+
+  // Pixel height of the part of a move that runs past midnight, or 0 when nothing
+  // spills. Measured against the end of the day, not `maxHour`: a narrowed window
+  // leaves plenty of events hanging below the last visible hour without them
+  // reaching the next day. Bails on the first line for a box that isn't being
+  // moved, which is every box but one.
+  const spillHeight = useDerivedValue(() => {
+    if (!moving.value || lifted.value || cellHeight.value <= 0) return 0;
+    const liveStartHours = startHours + moveOffset.value / cellHeight.value;
+    const overflowHours = liveStartHours + durationHours - HOURS_PER_DAY;
+    if (overflowHours <= 0) return 0;
+    const columnDelta = dayWidth > 0 ? Math.round(moveOffsetX.value / dayWidth) : 0;
+    const target = Math.min(Math.max(dayIndex + columnDelta, 0), dayCount - 1);
+    const next = target + nextDayDirection;
+    // Only when that column really is the next calendar day (`hiddenDays` can
+    // break the run), since the tail would otherwise land off-view.
+    if (next < 0 || next >= dayCount || dayOrdinals[next] - dayOrdinals[target] !== 1) return 0;
+    return Math.min(overflowHours, maxHour - minHour) * cellHeight.value;
+  }, [
+    startHours,
+    durationHours,
+    minHour,
+    maxHour,
+    dayWidth,
+    dayIndex,
+    dayCount,
+    dayOrdinals,
+    nextDayDirection,
+  ]);
+
+  // Mount the spill preview only while a drag is actually spilling, off the UI
+  // thread. It's one extra view plus the consumer's event renderer, so mounting it
+  // on every box would inflate the grid's node count for something that is almost
+  // never showing. Mounting it at the grab would also re-render at the most
+  // jank-sensitive moment of the gesture.
+  const [previewMounted, setPreviewMounted] = useState(false);
+  useAnimatedReaction(
+    () => spillHeight.value > 0,
+    (spilling, previous) => {
+      if (spilling !== previous) runOnJS(setPreviewMounted)(spilling);
+    },
   );
 
   // Clear the drag preview once the committed change re-renders this box at its
@@ -519,6 +665,7 @@ function AnimatedEventBox<T>({
       .enabled(canMove)
       .onStart((event) => {
         dragZ.value = DRAG_EVENT_Z;
+        moving.value = 1;
         edgeDir.value = 0;
         lifted.value = 0;
         // Where in the box the finger grabbed, and the live finger position, so
@@ -537,8 +684,14 @@ function AnimatedEventBox<T>({
         if (lifted.value && pagerLeftSV && pagerTopSV && ghostXSV && ghostYSV) {
           ghostXSV.value = event.absoluteX - grabX.value - pagerLeftSV.value;
           ghostYSV.value = event.absoluteY - grabY.value - pagerTopSV.value;
-        } else {
-          moveOffset.value = event.translationY;
+        } else if (cellHeight.value > 0) {
+          // Hold the start inside the day; the end is free to run past it (the
+          // spill preview shows where it lands). Same rule the commit applies, so
+          // the box never previews a position it can't be dropped in.
+          const startMinutes = startMinutesSV.value;
+          const dragged = startMinutes + (event.translationY / cellHeight.value) * MINUTES_PER_HOUR;
+          const held = clampMoveStartMinutes(dragged, minHour, maxHour, snapMinutes);
+          moveOffset.value = ((held - startMinutes) / MINUTES_PER_HOUR) * cellHeight.value;
           moveOffsetX.value = event.translationX;
         }
         // Dragging the finger to the pager's left/right edge arms an edge dwell
@@ -560,7 +713,17 @@ function AnimatedEventBox<T>({
         // gesture ends cleanly or is cancelled as the page moves under it), so the
         // drop lands even when onEnd doesn't fire on device. Nothing to do here.
         if (lifted.value) return;
-        const minuteDelta = snapDeltaMinutes(event.translationY, cellHeight.value, snapMinutes);
+        const startMinutes = startMinutesSV.value;
+        // Snap the vertical drag, then hold the start inside the day: a move keeps
+        // its duration, so the end may run past midnight and continue on the next
+        // day, but the event still starts in the column it was dropped on.
+        const minuteDelta =
+          clampMoveStartMinutes(
+            startMinutes + snapDeltaMinutes(event.translationY, cellHeight.value, snapMinutes),
+            minHour,
+            maxHour,
+            snapMinutes,
+          ) - startMinutes;
         // Map the horizontal drag to whole day columns, clamped so the event
         // can't leave the visible range.
         const rawDayDelta = dayWidth > 0 ? Math.round(event.translationX / dayWidth) : 0;
@@ -595,6 +758,10 @@ function AnimatedEventBox<T>({
           moveOffsetX.value = 0;
           lifted.value = 0;
         }
+        // The preview unmounts from the `spillHeight` reaction once the commit
+        // lands and clears `moveOffset`; this is the safety net for a cancel,
+        // where `onEnd` never runs.
+        moving.value = 0;
         runOnJS(releaseEdge)();
       });
     // Native: long-press to pick up. Web: activate past a small drag in either
@@ -611,6 +778,10 @@ function AnimatedEventBox<T>({
     moveOffset,
     moveOffsetX,
     dragZ,
+    moving,
+    startMinutesSV,
+    minHour,
+    maxHour,
     edgeDir,
     lifted,
     grabX,
@@ -802,7 +973,28 @@ function AnimatedEventBox<T>({
   // Only wrap in the move gesture when movable; the resize grips inside `box`
   // carry their own gestures, so a resize-only event still works.
   if (!canMove) return box;
-  return <GestureDetector gesture={moveGesture}>{box}</GestureDetector>;
+  return (
+    <>
+      <GestureDetector gesture={moveGesture}>{box}</GestureDetector>
+      {/* Skipped for a segment that already continues after: it owns a real
+          next-day box, so a preview on top of it would just double up. */}
+      {previewMounted && !positioned.continuesAfter ? (
+        <MoveSpillPreview
+          spillHeight={spillHeight}
+          moveOffsetX={moveOffsetX}
+          cellHeight={cellHeight}
+          dayLeftPx={dayLeftPx}
+          dayWidth={dayWidth}
+          nextDayDirection={nextDayDirection}
+          minHour={minHour}
+          event={positioned.event}
+          mode={mode}
+          renderEvent={renderEvent}
+          slotProps={slot("event", { themed: theme.containers.timeGridEvent })}
+        />
+      ) : null}
+    </>
+  );
 }
 
 /** Replace the hour-axis label. Receives the hour (0–23) and the `ampm` flag. */
@@ -1618,8 +1810,11 @@ function TimetablePageInner<T>({
                       positioned={positioned}
                       cellHeight={heightSource}
                       minHour={minHour}
+                      maxHour={maxHour}
                       left={dayLeft(dayIndex) + positioned.column * columnWidth}
                       width={columnWidth}
+                      dayLeftPx={dayLeft(dayIndex)}
+                      nextDayDirection={isRTL ? -1 : 1}
                       dayWidth={dayWidth}
                       dayIndex={dayIndex}
                       dayCount={days.length}
@@ -1961,6 +2156,7 @@ function TimeGridInner<T>({
     containerWidth,
     hourColumnWidth,
     minHour: clampedMinHour,
+    maxHour: clampedMaxHour,
     snapMinutes: Math.max(1, dragStepMinutes),
     onDragEvent,
     onChangeDate,
@@ -1983,6 +2179,7 @@ function TimeGridInner<T>({
         containerWidth: cw,
         hourColumnWidth: hcw,
         minHour: min,
+        maxHour: max,
         snapMinutes: snap,
         onDragEvent: onDrag,
         onChangeDate: onDate,
@@ -2003,7 +2200,9 @@ function TimeGridInner<T>({
       const hoursFromMin =
         (ghostLocalY - gridTop.value - HOUR_LABEL_TOP_INSET + scrollY.value) / cellHeight.value;
       const rawMinutes = (min + hoursFromMin) * MINUTES_PER_HOUR;
-      const minutes = Math.round(rawMinutes / snap) * snap;
+      // Same rule as an in-page move: the start stays in the day it landed on,
+      // while the duration is free to carry the end past midnight.
+      const minutes = clampMoveStartMinutes(Math.round(rawMinutes / snap) * snap, min, max, snap);
       const start = new Date(days[col]);
       start.setHours(0, 0, 0, 0);
       start.setMinutes(minutes);
@@ -2130,6 +2329,7 @@ function TimeGridInner<T>({
     containerWidth,
     hourColumnWidth,
     minHour: clampedMinHour,
+    maxHour: clampedMaxHour,
     snapMinutes: Math.max(1, dragStepMinutes),
     onDragEvent,
     onChangeDate,

--- a/packages/native/src/components/TimeGrid.tsx
+++ b/packages/native/src/components/TimeGrid.tsx
@@ -441,12 +441,19 @@ function AnimatedEventBox<T>({
   // ("Cannot copy value of type `Date`").
   const startHours = positioned.startHours;
   const durationHours = positioned.durationHours;
-  // Mirrored into a shared value so the move gesture can clamp against the
-  // segment's start without listing it as a dependency. A gesture memoized on a
-  // value the dragged event carries would be rebuilt under the finger, and so torn
-  // down mid-drag, the moment a consumer updates `events` (the same reason
-  // `commitDrag` reads the event through `latest`).
-  const startMinutesSV = useDerivedValue(() => startHours * MINUTES_PER_HOUR, [startHours]);
+  // Where the move gesture clamps from, mirrored into a shared value so it isn't a
+  // gesture dependency. A gesture memoized on a value the dragged event carries
+  // would be rebuilt under the finger, and so torn down mid-drag, the moment a
+  // consumer updates `events` (the same reason `commitDrag` reads the event
+  // through `latest`). `ownsStart` is false on a segment the layout clipped from
+  // an earlier day, whose 00:00 top edge isn't where the event starts.
+  const dragStartSV = useDerivedValue(
+    () => ({
+      minutes: startHours * MINUTES_PER_HOUR,
+      ownsStart: !positioned.continuesBefore,
+    }),
+    [startHours, positioned.continuesBefore],
+  );
 
   // Live pixel height of the box, driven on the UI thread by the shared
   // cellHeight (plus any in-progress resize). Handed to renderEvent so custom
@@ -677,9 +684,11 @@ function AnimatedEventBox<T>({
           // Hold the start inside the day; the end is free to run past it (the
           // spill preview shows where it lands). Same rule the commit applies, so
           // the box never previews a position it can't be dropped in.
-          const startMinutes = startMinutesSV.value;
+          const { minutes: startMinutes, ownsStart } = dragStartSV.value;
           const dragged = startMinutes + (event.translationY / cellHeight.value) * MINUTES_PER_HOUR;
-          const held = clampMoveStartMinutes(dragged, minHour, maxHour, snapMinutes);
+          const held = ownsStart
+            ? clampMoveStartMinutes(dragged, minHour, maxHour, snapMinutes)
+            : dragged;
           moveOffset.value = ((held - startMinutes) / MINUTES_PER_HOUR) * cellHeight.value;
           moveOffsetX.value = event.translationX;
         }
@@ -702,17 +711,17 @@ function AnimatedEventBox<T>({
         // gesture ends cleanly or is cancelled as the page moves under it), so the
         // drop lands even when onEnd doesn't fire on device. Nothing to do here.
         if (lifted.value) return;
-        const startMinutes = startMinutesSV.value;
+        const { minutes: startMinutes, ownsStart } = dragStartSV.value;
         // Snap the vertical drag, then hold the start inside the day: a move keeps
         // its duration, so the end may run past midnight and continue on the next
-        // day, but the event still starts in the column it was dropped on.
-        const minuteDelta =
-          clampMoveStartMinutes(
-            startMinutes + snapDeltaMinutes(event.translationY, cellHeight.value, snapMinutes),
-            minHour,
-            maxHour,
-            snapMinutes,
-          ) - startMinutes;
+        // day, but the event still starts in the column it was dropped on. A
+        // segment clipped from an earlier day is exempt: it doesn't own the start,
+        // so holding it would stop the whole event from being dragged earlier.
+        const snapped = snapDeltaMinutes(event.translationY, cellHeight.value, snapMinutes);
+        const minuteDelta = ownsStart
+          ? clampMoveStartMinutes(startMinutes + snapped, minHour, maxHour, snapMinutes) -
+            startMinutes
+          : snapped;
         // Map the horizontal drag to whole day columns, clamped so the event
         // can't leave the visible range.
         const rawDayDelta = dayWidth > 0 ? Math.round(event.translationX / dayWidth) : 0;
@@ -768,7 +777,7 @@ function AnimatedEventBox<T>({
     moveOffsetX,
     dragZ,
     moving,
-    startMinutesSV,
+    dragStartSV,
     minHour,
     maxHour,
     edgeDir,

--- a/packages/native/src/components/__tests__/TimeGrid.test.tsx
+++ b/packages/native/src/components/__tests__/TimeGrid.test.tsx
@@ -1,6 +1,6 @@
-import { fireEvent, render } from "@testing-library/react-native";
+import { act, fireEvent, render } from "@testing-library/react-native";
 import { StyleSheet, Text } from "react-native";
-import type { CalendarEvent } from "../../types";
+import type { CalendarEvent, RenderEventArgs } from "../../types";
 
 // Capture the props handed to the virtualized list, and render only the active
 // page through `renderItem`. The real LegendList can't lay out under Jest (no
@@ -30,6 +30,92 @@ const event: CalendarEvent<WithId> = {
 };
 
 const noop = () => {};
+
+const moveGestureHarness = () => {
+  const { __gestures } = require("react-native-gesture-handler") as {
+    __gestures: Array<{
+      calls: Record<string, unknown[]>;
+      handlers: {
+        onStart?: (event: Record<string, number>) => void;
+        onUpdate?: (event: Record<string, number>) => void;
+        onEnd?: (event: Record<string, number>) => void;
+        onFinalize?: () => void;
+      };
+    }>;
+  };
+  const gesture = __gestures.find(
+    (candidate) => candidate.calls.activateAfterLongPress?.[0] === 500,
+  );
+  if (!gesture) throw new Error("move gesture not found");
+  return gesture.handlers;
+};
+
+const animatedReactionHarness = () =>
+  require("react-native-reanimated") as {
+    __reactions: unknown[];
+    __flushAnimatedReactions: () => void;
+  };
+
+describe("TimeGrid midnight drag", () => {
+  beforeEach(() => {
+    const gestureHandler = require("react-native-gesture-handler") as { __gestures: unknown[] };
+    gestureHandler.__gestures.length = 0;
+    animatedReactionHarness().__reactions.length = 0;
+  });
+
+  it("commits an overnight move and exposes only the clipped source height", () => {
+    const onDragEvent = jest.fn();
+    let observedBoxHeight: { value: number } | undefined;
+    const ProbeEvent = ({ boxHeight, continuesBefore }: RenderEventArgs<WithId>) => {
+      if (!continuesBefore) observedBoxHeight = boxHeight;
+      return <Text>Late shift</Text>;
+    };
+    const late: CalendarEvent<WithId> = {
+      id: "late",
+      title: "Late shift",
+      start: new Date(2026, 0, 6, 19, 0, 0),
+      end: new Date(2026, 0, 6, 23, 0, 0),
+    };
+    const { getAllByText } = render(
+      <TimeGrid
+        mode="week"
+        date={new Date(2026, 0, 6, 12, 0, 0)}
+        events={[late]}
+        cellHeight={{ value: 48 } as never}
+        hourHeight={48}
+        weekStartsOn={1}
+        renderEvent={ProbeEvent}
+        keyExtractor={(item) => item.id}
+        onChangeDate={noop}
+        onPressEvent={noop}
+        onDragEvent={onDragEvent}
+      />,
+    );
+    const move = moveGestureHarness();
+
+    act(() => {
+      move.onStart?.({ x: 10, y: 10, absoluteX: 200, absoluteY: 300 });
+      move.onUpdate?.({ translationX: 0, translationY: 1200, absoluteX: 200, absoluteY: 1500 });
+      animatedReactionHarness().__flushAnimatedReactions();
+    });
+
+    // The start clamps to 23:45. Only 15 minutes remain before midnight, so the
+    // source renderer receives the same 32px minimum as its clipped wrapper.
+    expect(observedBoxHeight?.value).toBe(32);
+
+    act(() => {
+      move.onEnd?.({ translationX: 0, translationY: 1200 });
+      move.onFinalize?.();
+      animatedReactionHarness().__flushAnimatedReactions();
+    });
+
+    expect(onDragEvent).toHaveBeenCalledTimes(1);
+    const [, start, end] = onDragEvent.mock.calls[0] as [CalendarEvent<WithId>, Date, Date];
+    expect([start.getDate(), start.getHours(), start.getMinutes()]).toEqual([6, 23, 45]);
+    expect([end.getDate(), end.getHours(), end.getMinutes()]).toEqual([7, 3, 45]);
+    expect(getAllByText("Late shift")).toHaveLength(1);
+  });
+});
 
 describe("TimeGrid event updates", () => {
   // Pages are virtualized by date, so a list item only repaints when its key,


### PR DESCRIPTION
## Summary

Time-grid events can now be dragged past midnight in both renderers, with the overflow previewed in the next calendar-day column while preserving the event's duration.
Moving any visible segment shifts the complete multi-day event, while resize handles remain limited to the segment that owns the affected endpoint.
The shared clamp contract and renderer regressions cover narrowed windows, hidden days, invalid drag steps, custom renderer geometry, and native worklet serialization.
Validation includes lint, formatting, root and example typechecks, builds, 521 passing Jest assertions, a native-on-web drag to 22:45–02:45, and an iOS Release render with no `Date` copy error; the full Jest command still exits non-zero because of pre-existing LegendList timers after teardown.

Fixes #42
