### PR TITLE
fix: move multi-day event previews together

### DIFF
--- a/docs/guides/dragging.mdx
+++ b/docs/guides/dragging.mdx
@@ -38,7 +38,11 @@ still the horizontal drag.
 
 `onDragEvent` then receives a `start` and `end` on different dates. Dragging any
 day's segment of the resulting multi-day event moves the whole thing, so it never
-gets clipped to the day you grabbed.
+gets clipped to the day you grabbed. All visible segments preview the move together,
+including segments that enter a new column. Both dates shift together to preserve
+the event's duration. For example, moving a Tuesday 17:00 to Thursday 21:00 event
+one day earlier previews Monday 17:00 to Wednesday 21:00, whichever segment you grab.
+Use a resize grip to change just the start or end.
 
 ### Hide the drag handle
 

--- a/docs/reference/api.mdx
+++ b/docs/reference/api.mdx
@@ -71,6 +71,10 @@ pitfall this avoids.
 | `onPressDay`            | `(date) => void`                         | Tap a month day cell.                                                             |
 | `onPressMore`           | `(events, date) => void`                 | Tap the `+N more` overflow.                                                       |
 
+On the time grid, dragging any segment of a multi-day event moves its whole range.
+All visible segments preview the move together on both renderers. Moving preserves
+duration; resizing changes only the selected edge. See [dragging](/guides/dragging).
+
 ## Selection
 
 | Prop                  | Type                   | Notes                                            |
@@ -137,3 +141,7 @@ the [Date selection](/guides/selection) guide.
 `@super-calendar/core` also exports `clampMoveStartMinutes`. Use it when a custom
 time-grid drag must keep the moved start inside the visible hour window without
 shortening an event that continues past midnight.
+
+`resolveDraggedBounds` preserves elapsed duration when you pass the same minute
+delta for both edges, including across daylight saving changes. The end's local
+clock time can change to keep that duration.

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -53,6 +53,10 @@ import { clampMoveStartMinutes } from "@super-calendar/core";
 const startMinutes = clampMoveStartMinutes(rawStartMinutes, minHour, maxHour, snapMinutes);
 ```
 
+Use `resolveDraggedBounds` to commit a move or resize. Equal start and end deltas
+move the event while preserving elapsed duration, including across daylight
+saving changes. For a resize, pass zero for the edge you want to keep fixed.
+
 ## Documentation
 
 See the [full documentation](https://super-calendar.afonsojramos.me) and the [API reference](https://super-calendar.afonsojramos.me/reference/api).

--- a/packages/core/src/utils/__tests__/drag.test.ts
+++ b/packages/core/src/utils/__tests__/drag.test.ts
@@ -147,6 +147,17 @@ describe("resolveDraggedBounds", () => {
     expect(next?.end.getMinutes()).toBe(30);
   });
 
+  it.each([
+    [new Date(2026, 2, 28, 17), new Date(2026, 2, 30, 21)],
+    [new Date(2026, 9, 24, 17), new Date(2026, 9, 26, 21)],
+  ])("preserves elapsed duration when moving a range across a clock change", (start, end) => {
+    for (const delta of [-1440, 1440]) {
+      const next = resolveDraggedBounds(start, end, delta, delta, 15);
+      expect(next?.start).toEqual(shiftMinutes(start, delta));
+      expect(next!.end.getTime() - next!.start.getTime()).toBe(end.getTime() - start.getTime());
+    }
+  });
+
   it("resizes by moving only the end edge", () => {
     const next = resolveDraggedBounds(start, end, 0, 30, 15);
     expect(next?.start.getTime()).toBe(start.getTime()); // start untouched

--- a/packages/core/src/utils/drag.ts
+++ b/packages/core/src/utils/drag.ts
@@ -79,6 +79,7 @@ export function clampMoveStartMinutes(
 
 /** A copy of `date` shifted by `minutes` (may be negative). */
 export function shiftMinutes(date: Date, minutes: number): Date {
+  "worklet";
   const next = new Date(date);
   next.setMinutes(next.getMinutes() + minutes);
   return next;
@@ -87,7 +88,8 @@ export function shiftMinutes(date: Date, minutes: number): Date {
 /**
  * Resolve a committed drag into the event's new bounds: `start` shifts by
  * `deltaStartMinutes`, `end` by `deltaEndMinutes` (a move passes the same delta
- * to both; a resize passes 0 for the start). Returns `null` only when the change
+ * to both and preserves elapsed duration, including across DST; a resize passes
+ * 0 for the unchanged edge). Returns `null` only when the change
  * would *shrink* the event below one `snapMinutes` step, so a resize can't commit
  * a degenerate duration; a pure move (both deltas equal) keeps its duration and is
  * never rejected, even for an already sub-step event. Pure, so the commit path is
@@ -101,8 +103,11 @@ export function resolveDraggedBounds(
   snapMinutes: number,
 ): { start: Date; end: Date } | null {
   const nextStart = shiftMinutes(start, deltaStartMinutes);
-  const nextEnd = shiftMinutes(end, deltaEndMinutes);
   const oldDuration = end.getTime() - start.getTime();
+  const nextEnd =
+    deltaStartMinutes === deltaEndMinutes
+      ? new Date(nextStart.getTime() + oldDuration)
+      : shiftMinutes(end, deltaEndMinutes);
   const newDuration = nextEnd.getTime() - nextStart.getTime();
   // Reject only a shrink past one step — never a move, which preserves duration.
   if (newDuration < snapMinutes * 60_000 && newDuration < oldDuration) return null;

--- a/packages/dom/README.md
+++ b/packages/dom/README.md
@@ -52,6 +52,13 @@ export function MyCalendar() {
 
 For a custom picker, pair the headless hooks (`useDateRange`, `useMonthGrid`) with `MonthList` and `TimeGrid`, all re-exported from this package.
 
+## Moving events
+
+Pass `onDragEvent` and update your event state with the returned `start` and `end`.
+On the time grid, dragging any segment of a multi-day event previews the whole
+range moving together and preserves its duration. Drag a resize grip to change
+only the start or end. See the [dragging guide](https://super-calendar.afonsojramos.me/guides/dragging).
+
 ## Styling
 
 Out of the box the calendar is fully styled from the theme, no stylesheet required. To restyle a specific part with **Tailwind** or your own CSS, every element is a named slot: pass `classNames` (or `styles`) per slot, and use `data-*` state variants like `data-[today]:`.

--- a/packages/dom/src/TimeGrid.tsx
+++ b/packages/dom/src/TimeGrid.tsx
@@ -790,7 +790,11 @@ export function TimeGrid<T = unknown>({
       const startShift =
         d.kind === "resize" ? 0 : segmentStart.getTime() - origin.segmentStart.getTime();
       const endShift =
-        d.kind === "resize-start" ? 0 : segmentEnd.getTime() - origin.segmentEnd.getTime();
+        d.kind === "move"
+          ? startShift
+          : d.kind === "resize-start"
+            ? 0
+            : segmentEnd.getTime() - origin.segmentEnd.getTime();
       const start = new Date(held.event.start.getTime() + startShift);
       const end = new Date(held.event.end.getTime() + endShift);
       if (end > start) onDragEventRef.current?.(held.event, start, end);
@@ -948,6 +952,39 @@ export function TimeGrid<T = unknown>({
     () => days.map((day) => layoutDayEvents(events, day)),
     [days, events],
   );
+
+  // Keep the original boxes mounted for pointer capture, but replace every
+  // segment of a moving multi-day event with the same shifted range.
+  const moveOrigin = dragOrigin.current;
+  const heldEvent = draggedRef.current?.event;
+  const movingEvent =
+    heldEvent &&
+    (events.includes(heldEvent)
+      ? heldEvent
+      : (events.find(
+          (event) =>
+            event.start.getTime() === heldEvent.start.getTime() &&
+            event.end.getTime() === heldEvent.end.getTime() &&
+            event.title === heldEvent.title,
+        ) ?? heldEvent));
+  const multiDayMove =
+    !paged &&
+    drag?.kind === "move" &&
+    (drag.continuesBefore || drag.continuesAfter) &&
+    moveOrigin &&
+    movingEvent
+      ? (() => {
+          const target = days[moveOrigin.dayIndex + drag.dayDelta];
+          const segmentStart = addMinutes(startOfDay(target), Math.round(drag.startHours * 60));
+          const shift = segmentStart.getTime() - moveOrigin.segmentStart.getTime();
+          return {
+            ...movingEvent,
+            start: new Date(movingEvent.start.getTime() + shift),
+            end: new Date(movingEvent.end.getTime() + shift),
+            allDay: false,
+          };
+        })()
+      : null;
 
   // The tail of an in-progress move that runs past midnight, shown on `dayIndex`
   // so the drop is visible on both days at once. `drag` and `draggedRef` are set
@@ -1341,7 +1378,10 @@ export function TimeGrid<T = unknown>({
             // The tail of a move that runs past midnight, previewed at the top of
             // this column. The dragged event is looked up from its `drag.key`
             // ("<originColumn>:<index>"), so no extra state has to track it.
-            const spill = spillPreviewFor(dayIndex);
+            const spill = multiDayMove ? null : spillPreviewFor(dayIndex);
+            const moveSegment = multiDayMove
+              ? layoutDayEvents<T>([multiDayMove], day)[0]
+              : undefined;
             return (
               <div
                 key={day.toISOString()}
@@ -1423,7 +1463,11 @@ export function TimeGrid<T = unknown>({
                   // Not while paged: after a page change the origin box is gone and
                   // the ghost stands in, so a same-slot event on the new page (e.g. a
                   // recurring one) must not also render lifted.
-                  const active = !paged && drag?.key === key ? drag : null;
+                  const active =
+                    !paged && drag?.key === key && (!multiDayMove || pe.event === movingEvent)
+                      ? drag
+                      : null;
+                  const hiddenForMove = !!multiDayMove && pe.event === movingEvent;
                   const startHours = active ? active.startHours : pe.startHours;
                   const durationHours = active ? active.durationHours : pe.durationHours;
                   // Drop events that fall entirely outside the visible window; those
@@ -1498,7 +1542,7 @@ export function TimeGrid<T = unknown>({
                           : undefined
                       }
                       onClick={canMove ? undefined : onPress}
-                      {...dataState({ "data-dragging": !!active })}
+                      {...dataState({ "data-dragging": !!active && !hiddenForMove })}
                       {...slot("event", {
                         base: {
                           position: "absolute",
@@ -1514,6 +1558,7 @@ export function TimeGrid<T = unknown>({
                           touchAction: canMove ? "none" : "auto",
                           zIndex: active ? 3 : 1,
                           opacity: active ? 0.85 : 1,
+                          visibility: hiddenForMove ? "hidden" : undefined,
                           // Snap the dragged box over the target day column so the
                           // drop location is visible before release.
                           ...(active && active.dayOffsetPx !== 0
@@ -1569,6 +1614,42 @@ export function TimeGrid<T = unknown>({
                     </div>
                   );
                 })}
+                {moveSegment ? (
+                  <div
+                    aria-hidden
+                    {...dataState({ "data-dragging": true })}
+                    {...slot("event", {
+                      base: {
+                        position: "absolute",
+                        top: (moveSegment.startHours - windowStart) * hourHeight,
+                        left: 1,
+                        right: 1,
+                        height: Math.max(moveSegment.durationHours * hourHeight, 14),
+                        pointerEvents: "none",
+                        zIndex: 3,
+                        opacity: 0.85,
+                      },
+                    })}
+                  >
+                    {(() => {
+                      const args: DomRenderEventArgs<T> = {
+                        event: moveSegment.event,
+                        mode,
+                        isAllDay: false,
+                        boxHeight: Math.max(moveSegment.durationHours * hourHeight, 14),
+                        continuesBefore: moveSegment.continuesBefore,
+                        continuesAfter: moveSegment.continuesAfter,
+                        ampm,
+                        onPress: () => {},
+                      };
+                      return Renderer ? (
+                        <Renderer {...args} />
+                      ) : (
+                        <DefaultDomEvent {...args} theme={theme} boxProps={slot("eventBox")} />
+                      );
+                    })()}
+                  </div>
+                ) : null}
                 {spill ? (
                   <div
                     aria-hidden

--- a/packages/dom/src/__tests__/DateRangePicker.test.tsx
+++ b/packages/dom/src/__tests__/DateRangePicker.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render } from "@testing-library/react";
+import { cleanup, fireEvent, render } from "@testing-library/react";
 import { useState } from "react";
 import type { DateRange } from "@super-calendar/core";
 
@@ -17,6 +17,16 @@ import { DatePicker, DateRangePicker } from "../DateRangePicker";
 // The trigger is the only button with aria-haspopup; the calendar renders many
 // day buttons once open, so target the trigger explicitly.
 const trigger = (c: HTMLElement) => c.querySelector('[aria-haspopup="dialog"]') as HTMLElement;
+
+beforeEach(() => {
+  jest.useFakeTimers({ now: new Date(2026, 6, 1) });
+});
+
+afterEach(() => {
+  cleanup();
+  jest.runOnlyPendingTimers();
+  jest.useRealTimers();
+});
 
 describe("dom DatePicker", () => {
   it("shows the placeholder until a date is picked, then opens and selects", () => {

--- a/packages/dom/src/__tests__/TimeGrid.test.tsx
+++ b/packages/dom/src/__tests__/TimeGrid.test.tsx
@@ -352,6 +352,109 @@ describe("dom TimeGrid", () => {
     expect([end.getDate(), end.getHours()]).toEqual([26, 22]);
   });
 
+  it.each([0, 1, 2])(
+    "moves every multi-day preview segment when segment %i is grabbed",
+    (segment) => {
+      const trip: CalendarEvent = {
+        title: "Trip",
+        start: new Date(2026, 5, 24, 17),
+        end: new Date(2026, 5, 26, 21),
+      };
+      const onDragEvent = jest.fn();
+      const grid = (events: CalendarEvent[]) => (
+        <TimeGrid
+          date={day}
+          mode="week"
+          events={events}
+          hourHeight={48}
+          onDragEvent={onDragEvent}
+        />
+      );
+      const { container, getAllByText, rerender } = render(grid([trip]));
+      const originals = getAllByText("Trip").map(wrapperOf);
+      const box = originals[segment];
+      box.parentElement!.getBoundingClientRect = () => ({ width: 100 }) as DOMRect;
+      fireEvent.pointerDown(box, { clientX: 150, clientY: 300, pointerId: 1 });
+      fireEvent.pointerMove(box, { clientX: 50, clientY: 348, pointerId: 1 });
+
+      const previews = [...container.querySelectorAll<HTMLElement>("[data-dragging]")];
+      expect(
+        previews.map((preview) => new Date(preview.parentElement!.dataset.date!).getDate()),
+      ).toEqual([23, 24, 25]);
+      expect(previews.map((preview) => [preview.style.top, preview.style.height])).toEqual([
+        ["864px", "288px"],
+        ["0px", "1152px"],
+        ["0px", "1056px"],
+      ]);
+      expect(originals.every((original) => original.style.visibility === "hidden")).toBe(true);
+      expect(onDragEvent).not.toHaveBeenCalled();
+      rerender(grid([{ ...trip }]));
+      expect(originals.every((original) => original.style.visibility === "hidden")).toBe(true);
+
+      fireEvent.pointerUp(box, { clientX: 50, clientY: 348, pointerId: 1 });
+      expect(onDragEvent).toHaveBeenCalledWith(
+        trip,
+        new Date(2026, 5, 23, 18),
+        new Date(2026, 5, 25, 22),
+      );
+      expect(container.querySelectorAll("[data-dragging]")).toHaveLength(0);
+      expect(originals.every((original) => original.style.visibility !== "hidden")).toBe(true);
+    },
+  );
+
+  it("restores all multi-day segments when a move is cancelled", () => {
+    const trip: CalendarEvent = {
+      title: "Trip",
+      start: new Date(2026, 5, 24, 22),
+      end: new Date(2026, 5, 26, 10),
+    };
+    const onDragEvent = jest.fn();
+    const { container, getAllByText } = render(
+      <TimeGrid date={day} mode="week" events={[trip]} hourHeight={48} onDragEvent={onDragEvent} />,
+    );
+    const originals = getAllByText("Trip").map(wrapperOf);
+    fireEvent.pointerDown(originals[0], { clientY: 300, pointerId: 1 });
+    fireEvent.pointerMove(originals[0], { clientY: 348, pointerId: 1 });
+    fireEvent.pointerCancel(originals[0], { pointerId: 1 });
+    expect(onDragEvent).not.toHaveBeenCalled();
+    expect(container.querySelectorAll("[data-dragging]")).toHaveLength(0);
+    expect(originals.every((original) => original.style.visibility !== "hidden")).toBe(true);
+  });
+
+  it("keeps the held event when another event is inserted during a multi-day move", () => {
+    const trip: CalendarEvent = {
+      title: "Trip",
+      start: new Date(2026, 5, 24, 17),
+      end: new Date(2026, 5, 26, 21),
+    };
+    const onDragEvent = jest.fn();
+    const grid = (events: CalendarEvent[]) => (
+      <TimeGrid date={day} mode="week" events={events} hourHeight={48} onDragEvent={onDragEvent} />
+    );
+    const { container, getAllByText, getByText, rerender } = render(grid([trip]));
+    const box = wrapperOf(getAllByText("Trip")[0]);
+    fireEvent.pointerDown(box, { clientY: 300, pointerId: 1 });
+    fireEvent.pointerMove(box, { clientY: 348, pointerId: 1 });
+    rerender(
+      grid([
+        { title: "Earlier", start: new Date(2026, 5, 24, 10), end: new Date(2026, 5, 24, 11) },
+        { ...trip },
+      ]),
+    );
+    const earlier = wrapperOf(getByText("Earlier"));
+    expect(earlier.style.top).toBe("480px");
+    expect(earlier.hasAttribute("data-dragging")).toBe(false);
+    const previews = [...container.querySelectorAll("[data-dragging]")];
+    expect(previews).toHaveLength(3);
+    expect(previews.every((preview) => preview.textContent?.includes("Trip"))).toBe(true);
+    fireEvent.pointerUp(box, { clientY: 348, pointerId: 1 });
+    expect(onDragEvent).toHaveBeenCalledWith(
+      trip,
+      new Date(2026, 5, 24, 18),
+      new Date(2026, 5, 26, 22),
+    );
+  });
+
   it("offers the bottom resize grip only on the segment that owns the event's end", () => {
     const trip: CalendarEvent[] = [
       { title: "Trip", start: new Date(2026, 5, 24, 22, 0), end: new Date(2026, 5, 26, 10, 0) },

--- a/packages/native/README.md
+++ b/packages/native/README.md
@@ -63,6 +63,13 @@ export function MyCalendar() {
 }
 ```
 
+## Moving events
+
+Pass `onDragEvent` and update your event state with the returned `start` and `end`.
+On the time grid, dragging any segment of a multi-day event previews the whole
+range moving together and preserves its duration. Drag a resize grip to change
+only the start or end. See the [dragging guide](https://super-calendar.afonsojramos.me/guides/dragging).
+
 ## Styling with Tailwind
 
 Every styleable part is a named slot that accepts a class (resolved by a Tailwind runtime such as [uniwind](https://docs.uniwind.dev) or NativeWind) and/or a style override. A classed slot drops its built-in themed styles, so your classes own the look:

--- a/packages/native/src/components/MultiDayMovePreview.tsx
+++ b/packages/native/src/components/MultiDayMovePreview.tsx
@@ -1,0 +1,164 @@
+import { addDays, differenceInCalendarDays, startOfDay } from "date-fns";
+import { useMemo, useState } from "react";
+import Animated, {
+  runOnJS,
+  type SharedValue,
+  useAnimatedReaction,
+  useAnimatedStyle,
+  useDerivedValue,
+} from "react-native-reanimated";
+import { shiftMinutes } from "@super-calendar/core";
+import type { CalendarEvent, CalendarMode, RenderEvent } from "../types";
+import { useCalendarTheme } from "../theme";
+import { useSlots } from "../utils/slots";
+import type { TimeGridSlot } from "./TimeGrid";
+
+export type MultiDayMove<T> = {
+  event: CalendarEvent<T>;
+  eventIndex: number;
+  phase: "dragging" | "dropped";
+  dayIndex: number;
+  offsetX: SharedValue<number>;
+  offsetY: SharedValue<number>;
+  lifted: SharedValue<number>;
+};
+
+type PreviewProps<T> = {
+  move: MultiDayMove<T>;
+  days: Date[];
+  cellHeight: SharedValue<number>;
+  dayWidth: number;
+  hourColumnWidth: number;
+  minHour: number;
+  mode: CalendarMode;
+  renderEvent: RenderEvent<T>;
+};
+
+const noop = () => {};
+const MIN_EVENT_HEIGHT = 32;
+
+// Mount once on grab. Only numbers and shared values cross to the UI thread;
+// moving the pointer does not rerender the page or rebuild its gestures.
+export function MultiDayMovePreview<T>(props: PreviewProps<T>) {
+  const { move, days } = props;
+  const dayOffsets = useMemo(
+    () => days.map((day) => differenceInCalendarDays(day, days[move.dayIndex]) * 1440),
+    [days, move],
+  );
+  return days.map((day, index) => (
+    <PreviewDay
+      key={day.toISOString()}
+      {...props}
+      dayOffsets={dayOffsets}
+      index={index}
+      dayStart={startOfDay(day).getTime()}
+      dayEnd={addDays(startOfDay(day), 1).getTime()}
+    />
+  ));
+}
+
+function PreviewDay<T>({
+  move,
+  cellHeight,
+  dayWidth,
+  hourColumnWidth,
+  minHour,
+  mode,
+  renderEvent: RenderEventComponent,
+  dayOffsets,
+  index,
+  dayStart,
+  dayEnd,
+}: PreviewProps<T> & {
+  dayOffsets: number[];
+  index: number;
+  dayStart: number;
+  dayEnd: number;
+}) {
+  const theme = useCalendarTheme();
+  const slot = useSlots<TimeGridSlot>();
+  const { offsetX, offsetY, lifted, dayIndex, event } = move;
+  const duration = event.end.getTime() - event.start.getTime();
+  const startTimestamp = event.start.getTime();
+  const segment = useDerivedValue(() => {
+    const columnDelta = dayWidth > 0 ? Math.round(offsetX.value / dayWidth) : 0;
+    const target = Math.min(Math.max(dayIndex + columnDelta, 0), dayOffsets.length - 1);
+    const minuteDelta = cellHeight.value > 0 ? (offsetY.value / cellHeight.value) * 60 : 0;
+    const start = shiftMinutes(
+      new Date(startTimestamp),
+      dayOffsets[target] + minuteDelta,
+    ).getTime();
+    const end = start + duration;
+    const visible = !lifted.value && start < dayEnd && end > dayStart;
+    return {
+      top: (Math.max(start, dayStart) - dayStart) / 3_600_000,
+      hours: visible
+        ? Math.max((Math.min(end, dayEnd) - Math.max(start, dayStart)) / 3_600_000, 0.25)
+        : 0,
+      continuesBefore: start < dayStart,
+      continuesAfter: end > dayEnd,
+    };
+  }, [dayWidth, dayIndex, dayOffsets, startTimestamp, duration, dayStart, dayEnd]);
+  const boxHeight = useDerivedValue(() =>
+    segment.value.hours > 0
+      ? Math.max(segment.value.hours * cellHeight.value, MIN_EVENT_HEIGHT)
+      : 0,
+  );
+  const style = useAnimatedStyle(
+    () => ({
+      top: (segment.value.top - minHour) * cellHeight.value,
+      height: boxHeight.value,
+      opacity: boxHeight.value > 0 ? 1 : 0,
+    }),
+    [minHour],
+  );
+  const [continuation, setContinuation] = useState(() => ({
+    continuesBefore: segment.value.continuesBefore,
+    continuesAfter: segment.value.continuesAfter,
+  }));
+  useAnimatedReaction(
+    () => ({
+      continuesBefore: segment.value.continuesBefore,
+      continuesAfter: segment.value.continuesAfter,
+    }),
+    (next, previous) => {
+      if (
+        previous &&
+        (next.continuesBefore !== previous.continuesBefore ||
+          next.continuesAfter !== previous.continuesAfter)
+      ) {
+        runOnJS(setContinuation)(next);
+      }
+    },
+  );
+  const eventSlot = slot("event", { themed: theme.containers.timeGridEvent });
+  return (
+    <Animated.View
+      {...eventSlot}
+      testID="multi-day-move-preview"
+      pointerEvents="none"
+      accessibilityElementsHidden
+      importantForAccessibility="no-hide-descendants"
+      style={[
+        {
+          position: "absolute",
+          overflow: "hidden",
+          padding: 2,
+          left: hourColumnWidth + index * dayWidth,
+          width: dayWidth,
+          zIndex: 100,
+        },
+        eventSlot.style,
+        style,
+      ]}
+    >
+      <RenderEventComponent
+        event={event}
+        mode={mode}
+        boxHeight={boxHeight}
+        {...continuation}
+        onPress={noop}
+      />
+    </Animated.View>
+  );
+}

--- a/packages/native/src/components/TimeGrid.tsx
+++ b/packages/native/src/components/TimeGrid.tsx
@@ -17,8 +17,10 @@ import {
 } from "date-fns";
 import {
   createContext,
+  type Dispatch,
   memo,
   type ReactElement,
+  type SetStateAction,
   useCallback,
   useContext,
   useEffect,
@@ -96,6 +98,7 @@ import { useWebGridZoom } from "../utils/useWebGridZoom";
 import { useWebPagerKeys } from "../utils/useWebPagerKeys";
 import { withEventAccessibilityLabel } from "../utils/withEventAccessibilityLabel";
 import { AllDayLane } from "./AllDayLane";
+import { type MultiDayMove, MultiDayMovePreview } from "./MultiDayMovePreview";
 
 // Horizontal swipe paging doesn't translate to web; there we disable it and page
 // with the arrow keys instead.
@@ -310,6 +313,9 @@ const HOUR_LABEL_NUDGE = 6;
 
 type AnimatedEventBoxProps<T> = {
   positioned: PositionedEvent<T>;
+  eventIndex: number;
+  movingEvent: CalendarEvent<T> | null;
+  onMovePreview: Dispatch<SetStateAction<MultiDayMove<T> | null>>;
   cellHeight: SharedValue<number>;
   minHour: number;
   maxHour: number;
@@ -351,6 +357,9 @@ type AnimatedEventBoxProps<T> = {
 
 function AnimatedEventBox<T>({
   positioned,
+  eventIndex,
+  movingEvent,
+  onMovePreview,
   cellHeight,
   minHour,
   maxHour,
@@ -442,6 +451,8 @@ function AnimatedEventBox<T>({
   const startHours = positioned.startHours;
   const durationHours = positioned.durationHours;
   const ownsStart = !positioned.continuesBefore;
+  const multiDay = positioned.continuesBefore || positioned.continuesAfter;
+  const hiddenForMove = positioned.event === movingEvent;
   // Where the move gesture clamps from, mirrored into a shared value so it isn't a
   // gesture dependency. A gesture memoized on a value the dragged event carries
   // would be rebuilt under the finger, and so torn down mid-drag, the moment a
@@ -503,7 +514,7 @@ function AnimatedEventBox<T>({
   // reaching the next day. Bails on the first line for a box that isn't being
   // moved, which is every box but one.
   const spillHeight = useDerivedValue(() => {
-    if (!moving.value || lifted.value || cellHeight.value <= 0) return 0;
+    if (multiDay || !moving.value || lifted.value || cellHeight.value <= 0) return 0;
     const liveStartHours = startHours + moveOffset.value / cellHeight.value;
     const overflowHours = liveStartHours + durationHours - HOURS_PER_DAY;
     if (overflowHours <= 0) return 0;
@@ -524,6 +535,7 @@ function AnimatedEventBox<T>({
     dayCount,
     dayOrdinals,
     nextDayDirection,
+    multiDay,
   ]);
 
   // Mount the spill preview only while a drag is actually spilling, off the UI
@@ -565,8 +577,8 @@ function AnimatedEventBox<T>({
 
   // Keep the latest event/handler in a ref so the gestures stay memoized but
   // never call into a stale closure.
-  const latest = useRef({ event: positioned.event, onDragEvent, onDragStart });
-  latest.current = { event: positioned.event, onDragEvent, onDragStart };
+  const latest = useRef({ event: positioned.event, eventIndex, onDragEvent, onDragStart });
+  latest.current = { event: positioned.event, eventIndex, onDragEvent, onDragStart };
 
   // Snap the box back to where it started (drop rejected or degenerate).
   const snapBack = useCallback(() => {
@@ -598,9 +610,14 @@ function AnimatedEventBox<T>({
       }
       // A handler may return false to reject the drop (e.g. an overlap or an
       // out-of-bounds slot); snap the box back to its original place.
-      if (handler(event, next.start, next.end) === false) snapBack();
+      if (handler(event, next.start, next.end) === false) {
+        snapBack();
+        onMovePreview(null);
+      } else if (multiDay && deltaStartMin === deltaEndMin) {
+        onMovePreview((move) => (move ? { ...move, phase: "dropped" } : null));
+      }
     },
-    [snapMinutes, snapBack],
+    [snapMinutes, snapBack, multiDay, onMovePreview],
   );
 
   // Fired on the JS thread when the gesture grabs the event, so consumers can
@@ -608,6 +625,21 @@ function AnimatedEventBox<T>({
   const notifyDragStart = useCallback(() => {
     latest.current.onDragStart?.(latest.current.event);
   }, []);
+
+  const beginMovePreview = useCallback(() => {
+    if (multiDay) {
+      onMovePreview({
+        event: latest.current.event,
+        eventIndex: latest.current.eventIndex,
+        phase: "dragging",
+        dayIndex,
+        offsetX: moveOffsetX,
+        offsetY: moveOffset,
+        lifted,
+      });
+    }
+  }, [multiDay, onMovePreview, dayIndex, moveOffsetX, moveOffset, lifted]);
+  const endMovePreview = useCallback(() => onMovePreview(null), [onMovePreview]);
 
   // Edge auto-advance dwell. Dragging the event past the visible columns and
   // holding there pages the view one period and carries the event onto it: same
@@ -683,6 +715,7 @@ function AnimatedEventBox<T>({
         grabY.value = event.y;
         liveAbsX.value = event.absoluteX;
         liveAbsY.value = event.absoluteY;
+        runOnJS(beginMovePreview)();
         runOnJS(notifyDragStart)();
       })
       .onUpdate((event) => {
@@ -743,6 +776,7 @@ function AnimatedEventBox<T>({
         if (minuteDelta === 0 && dayDelta === 0) {
           moveOffset.value = 0;
           moveOffsetX.value = 0;
+          runOnJS(endMovePreview)();
           return;
         }
         // Hold the snapped position so the box doesn't flash back to the
@@ -757,7 +791,7 @@ function AnimatedEventBox<T>({
         const totalDelta = minuteDelta + calendarDayDelta * MINUTES_PER_DAY;
         runOnJS(commitDrag)(totalDelta, totalDelta);
       })
-      .onFinalize(() => {
+      .onFinalize((_event, success) => {
         dragZ.value = 0;
         // Commit the cross-week drop here: onFinalize fires on every gesture end,
         // including the cancel RNGH reports when the source page moves under the
@@ -768,11 +802,17 @@ function AnimatedEventBox<T>({
           moveOffset.value = 0;
           moveOffsetX.value = 0;
           lifted.value = 0;
+          runOnJS(endMovePreview)();
         }
         // The preview unmounts from the `spillHeight` reaction once the commit
         // lands and clears `moveOffset`; this is the safety net for a cancel,
         // where `onEnd` never runs.
         moving.value = 0;
+        if (multiDay && !success) {
+          moveOffset.value = 0;
+          moveOffsetX.value = 0;
+          runOnJS(endMovePreview)();
+        }
         runOnJS(releaseEdge)();
       });
     // Native: long-press to pick up. Web: activate past a small drag in either
@@ -810,6 +850,9 @@ function AnimatedEventBox<T>({
     dayCount,
     dayOrdinals,
     commitDrag,
+    multiDay,
+    beginMovePreview,
+    endMovePreview,
     notifyDragStart,
     onEdgeAdvance,
     armEdge,
@@ -946,7 +989,10 @@ function AnimatedEventBox<T>({
     themed: theme.containers.timeGridEvent,
   });
   const box = (
-    <Animated.View {...eventSlot} style={[eventSlot.style, boxStyle]}>
+    <Animated.View
+      {...eventSlot}
+      style={[eventSlot.style, boxStyle, hiddenForMove ? { opacity: 0 } : null]}
+    >
       <RenderEventComponent
         event={positioned.event}
         mode={mode}
@@ -1407,6 +1453,23 @@ function TimetablePageInner<T>({
   );
 
   const dayLayouts = useMemo(() => days.map((day) => layoutDayEvents(events, day)), [days, events]);
+  const [multiDayMove, setMultiDayMove] = useState<MultiDayMove<T> | null>(null);
+  const movingEvent = multiDayMove
+    ? (events.find(
+        (event, index) =>
+          keyExtractor(event, index) === keyExtractor(multiDayMove.event, multiDayMove.eventIndex),
+      ) ?? null)
+    : null;
+  useEffect(() => {
+    if (
+      multiDayMove?.phase === "dropped" &&
+      (!movingEvent ||
+        movingEvent.start.getTime() !== multiDayMove.event.start.getTime() ||
+        movingEvent.end.getTime() !== multiDayMove.event.end.getTime())
+    ) {
+      setMultiDayMove(null);
+    }
+  }, [multiDayMove, movingEvent]);
 
   // Map a tap on empty grid space back to the date+time it represents. Reads the
   // live row height on the JS thread to convert the touch Y into minutes.
@@ -1819,6 +1882,9 @@ function TimetablePageInner<T>({
                       // flattened list of all days' boxes.
                       key={`${dayIndex}:${keyExtractor(positioned.event, eventIndex)}`}
                       positioned={positioned}
+                      eventIndex={events.indexOf(positioned.event)}
+                      movingEvent={movingEvent}
+                      onMovePreview={setMultiDayMove}
                       cellHeight={heightSource}
                       minHour={minHour}
                       maxHour={maxHour}
@@ -1846,6 +1912,19 @@ function TimetablePageInner<T>({
                   );
                 }),
             )}
+
+            {multiDayMove ? (
+              <MultiDayMovePreview
+                move={multiDayMove}
+                days={days}
+                cellHeight={heightSource}
+                dayWidth={dayWidth}
+                hourColumnWidth={hourColumnWidth}
+                minHour={minHour}
+                mode={mode}
+                renderEvent={renderEvent}
+              />
+            ) : null}
 
             {showNowIndicator && nowDayIndex >= 0 && nowInWindow ? (
               <NowIndicator

--- a/packages/native/src/components/__tests__/MonthList.test.tsx
+++ b/packages/native/src/components/__tests__/MonthList.test.tsx
@@ -1,7 +1,17 @@
-import { render } from "@testing-library/react-native";
+import { cleanup, render } from "@testing-library/react-native";
 import type { CalendarEvent } from "../../types";
 import { DefaultEvent } from "../DefaultEvent";
 import { MonthList } from "../MonthList";
+
+beforeEach(() => {
+  jest.useFakeTimers();
+});
+
+afterEach(() => {
+  cleanup();
+  jest.runOnlyPendingTimers();
+  jest.useRealTimers();
+});
 
 const baseProps = {
   date: new Date(2026, 5, 15), // June 2026

--- a/packages/native/src/components/__tests__/TimeGrid.test.tsx
+++ b/packages/native/src/components/__tests__/TimeGrid.test.tsx
@@ -1,5 +1,5 @@
 import { act, fireEvent, render } from "@testing-library/react-native";
-import { StyleSheet, Text } from "react-native";
+import { Dimensions, StyleSheet, Text } from "react-native";
 import type { CalendarEvent, RenderEventArgs } from "../../types";
 
 // Capture the props handed to the virtualized list, and render only the active
@@ -31,7 +31,7 @@ const event: CalendarEvent<WithId> = {
 
 const noop = () => {};
 
-const moveGestureHarness = () => {
+const moveGestureHarness = (index = 0) => {
   const { __gestures } = require("react-native-gesture-handler") as {
     __gestures: Array<{
       calls: Record<string, unknown[]>;
@@ -39,13 +39,13 @@ const moveGestureHarness = () => {
         onStart?: (event: Record<string, number>) => void;
         onUpdate?: (event: Record<string, number>) => void;
         onEnd?: (event: Record<string, number>) => void;
-        onFinalize?: () => void;
+        onFinalize?: (event?: Record<string, number>, success?: boolean) => void;
       };
     }>;
   };
-  const gesture = __gestures.find(
+  const gesture = __gestures.filter(
     (candidate) => candidate.calls.activateAfterLongPress?.[0] === 500,
-  );
+  )[index];
   if (!gesture) throw new Error("move gesture not found");
   return gesture.handlers;
 };
@@ -114,6 +114,168 @@ describe("TimeGrid midnight drag", () => {
     expect([start.getDate(), start.getHours(), start.getMinutes()]).toEqual([6, 23, 45]);
     expect([end.getDate(), end.getHours(), end.getMinutes()]).toEqual([7, 3, 45]);
     expect(getAllByText("Late shift")).toHaveLength(1);
+  });
+
+  it.each([0, 1, 2])(
+    "moves every multi-day preview segment when segment %i is grabbed",
+    (segment) => {
+      const trip: CalendarEvent<WithId> = {
+        id: "trip",
+        title: "Trip",
+        start: new Date(2026, 0, 6, 17),
+        end: new Date(2026, 0, 8, 21),
+      };
+      const onDragEvent = jest.fn();
+      const observed: Array<RenderEventArgs<WithId>> = [];
+      const ProbeEvent = (args: RenderEventArgs<WithId>) => {
+        observed.push(args);
+        return <Text>Trip</Text>;
+      };
+      const grid = (events: CalendarEvent<WithId>[]) => (
+        <TimeGrid
+          mode="week"
+          date={trip.start}
+          events={events}
+          hourHeight={48}
+          cellHeight={{ value: 48 } as never}
+          weekStartsOn={1}
+          hideHours
+          renderEvent={ProbeEvent}
+          keyExtractor={(item) => item.id}
+          onChangeDate={noop}
+          onPressEvent={noop}
+          onDragEvent={onDragEvent}
+        />
+      );
+      const { getAllByTestId, queryAllByTestId, rerender, UNSAFE_getAllByType } = render(
+        grid([trip]),
+      );
+      const move = moveGestureHarness(segment);
+      act(() => move.onStart?.({ x: 10, y: 10, absoluteX: 200, absoluteY: 300 }));
+      expect(
+        getAllByTestId("multi-day-move-preview", { includeHiddenElements: true }),
+      ).toHaveLength(7);
+      const previews = observed.slice(-7);
+      const translationX = Dimensions.get("window").width / 7;
+      act(() => {
+        move.onUpdate?.({ translationX, translationY: 48, absoluteX: 300, absoluteY: 348 });
+        animatedReactionHarness().__flushAnimatedReactions();
+      });
+      // Jan 7 18:00 through Jan 9 22:00, including the previously empty Friday.
+      expect(previews.map((preview) => preview.boxHeight?.value)).toEqual([
+        0, 0, 288, 1152, 1056, 0, 0,
+      ]);
+      expect(onDragEvent).not.toHaveBeenCalled();
+      rerender(grid([{ ...trip }]));
+      expect(
+        UNSAFE_getAllByType(ProbeEvent)
+          .slice(0, 3)
+          .map((node) => StyleSheet.flatten(node.parent!.props.style).opacity),
+      ).toEqual([0, 0, 0]);
+      act(() => {
+        move.onEnd?.({ translationX, translationY: 48 });
+        move.onFinalize?.({}, true);
+      });
+      expect(onDragEvent).toHaveBeenCalledWith(
+        trip,
+        new Date(2026, 0, 7, 18),
+        new Date(2026, 0, 9, 22),
+      );
+      // A controlled consumer may update after the gesture ends. Keep the
+      // complete preview at its snapped position until that update arrives.
+      expect(
+        queryAllByTestId("multi-day-move-preview", { includeHiddenElements: true }),
+      ).toHaveLength(7);
+      expect(previews.map((preview) => preview.boxHeight?.value)).toEqual([
+        0, 0, 288, 1152, 1056, 0, 0,
+      ]);
+      rerender(grid([{ ...trip, start: new Date(2026, 0, 7, 18), end: new Date(2026, 0, 9, 22) }]));
+      expect(
+        queryAllByTestId("multi-day-move-preview", { includeHiddenElements: true }),
+      ).toHaveLength(0);
+    },
+  );
+
+  it.each(["cancel", "reject"])("clears the multi-day preview on %s", (finish) => {
+    const trip: CalendarEvent<WithId> = { ...event, end: new Date(2026, 0, 8, 10) };
+    const onDragEvent = jest.fn(() => false);
+    const { queryAllByTestId } = render(
+      <TimeGrid
+        mode="week"
+        date={trip.start}
+        events={[trip]}
+        hourHeight={48}
+        cellHeight={{ value: 48 } as never}
+        weekStartsOn={1}
+        renderEvent={DefaultEvent}
+        keyExtractor={(item) => item.id}
+        onChangeDate={noop}
+        onPressEvent={noop}
+        onDragEvent={onDragEvent}
+      />,
+    );
+    const move = moveGestureHarness();
+    act(() => {
+      move.onStart?.({ x: 10, y: 10, absoluteX: 200, absoluteY: 300 });
+      move.onUpdate?.({ translationX: 0, translationY: 48, absoluteX: 200, absoluteY: 348 });
+    });
+    expect(
+      queryAllByTestId("multi-day-move-preview", { includeHiddenElements: true }),
+    ).toHaveLength(7);
+    act(() => {
+      if (finish === "reject") move.onEnd?.({ translationX: 0, translationY: 48 });
+      move.onFinalize?.({}, finish === "reject");
+    });
+    expect(onDragEvent).toHaveBeenCalledTimes(finish === "reject" ? 1 : 0);
+    expect(
+      queryAllByTestId("multi-day-move-preview", { includeHiddenElements: true }),
+    ).toHaveLength(0);
+  });
+
+  it("previews the committed end when vertical movement crosses a clock change", () => {
+    const trip: CalendarEvent<WithId> = {
+      id: "trip",
+      title: "Trip",
+      start: new Date(2026, 2, 29, 1),
+      end: new Date(2026, 2, 30, 10),
+    };
+    const date = new Date(2026, 2, 30);
+    const onDragEvent = jest.fn();
+    const observed: Array<RenderEventArgs<WithId>> = [];
+    const ProbeEvent = (args: RenderEventArgs<WithId>) => {
+      observed.push(args);
+      return <Text>Trip</Text>;
+    };
+    render(
+      <TimeGrid
+        mode="3days"
+        date={date}
+        weekStartsOn={1}
+        events={[trip]}
+        hourHeight={48}
+        cellHeight={{ value: 48 } as never}
+        renderEvent={ProbeEvent}
+        keyExtractor={(item) => item.id}
+        onChangeDate={noop}
+        onPressEvent={noop}
+        onDragEvent={onDragEvent}
+      />,
+    );
+    const move = moveGestureHarness();
+    act(() => move.onStart?.({ x: 10, y: 10, absoluteX: 200, absoluteY: 300 }));
+    const previews = observed.slice(-3);
+    act(() => {
+      move.onUpdate?.({ translationX: 0, translationY: 96, absoluteX: 200, absoluteY: 396 });
+      move.onEnd?.({ translationX: 0, translationY: 96 });
+      move.onFinalize?.({}, true);
+    });
+    const [, start, end] = onDragEvent.mock.calls[0] as [CalendarEvent<WithId>, Date, Date];
+    expect(end.getTime() - start.getTime()).toBe(trip.end.getTime() - trip.start.getTime());
+    expect(previews.map((preview) => preview.boxHeight?.value)).toEqual([
+      ((end.getTime() - date.getTime()) / 3_600_000) * 48,
+      0,
+      0,
+    ]);
   });
 });
 


### PR DESCRIPTION
Dragging one segment of a multi-day event previously left its other segments anchored. Both TimeGrid renderers now preview the whole event moving together and preserve its elapsed duration, including across daylight-saving changes. Resize grips still change only the selected edge.

The native preview stays in its dropped position until the controlled event update arrives, and clears on cancellation or rejection. The test harness also fixes date-dependent picker fixtures and drains pending native month-list timers so the full suite can pass.

Validation: all 557 tests pass, along with lint, formatting, root and example typechecks, package builds, and attw/publint for all three packages. Browser checks covered DOM and React Native Web, including cross-week dragging; iOS and Android device testing was not run.

Fixes #51
