### PR TITLE
feat: make time-grid event height floor and gap configurable

### DIFF
--- a/docs/guides/events.mdx
+++ b/docs/guides/events.mdx
@@ -68,7 +68,11 @@ On the day/week grid a timed event's box is sized to its duration and given to y
 renderer as `boxHeight`, so it tracks the grid's hour scale as the grid zooms or
 resizes. Fit your content to `boxHeight`: the built-in renderer clamps its own
 content, and a custom renderer should adapt (show less, or scroll) rather than
-assume a fixed size, since content taller than the slot is clipped.
+assume a fixed size, since content taller than the slot is clipped. `boxHeight`
+never drops below the grid's `minEventHeight` (default 32 on native, 14 on the
+dom renderer); set it to `0` if your renderer should get the exact duration
+height. The box is inset from its slot by `eventGap` (see
+[Event boxes](/guides/time-grid#event-boxes)).
 
 ## Lighter touches
 

--- a/docs/guides/time-grid.mdx
+++ b/docs/guides/time-grid.mdx
@@ -39,6 +39,31 @@ choose.
   `[0, 6]` for a Monday–Friday business week. Count-based views keep their
   column count by skipping hidden days.
 
+## Event boxes
+
+A timed event's box is sized to its duration, with two guards you can tune:
+
+- `minEventHeight` — the floor on a box's pixel height, so a 5-minute event
+  stays legible and tappable. It is also the floor of the `boxHeight` passed to
+  your [`renderEvent`](/guides/events#render-your-own-event). Default 32 on
+  native, 14 on the dom renderer. Pass `0` to size every box strictly by its
+  duration.
+- `eventGap` — the inset in pixels between a box and its slot on each side, so
+  adjacent boxes and column edges get some breathing room. Default 2 on native,
+  1 on the dom renderer. Pass `0` to let events fill the full slot.
+
+```tsx
+<Calendar
+  mode="week"
+  date={date}
+  events={events}
+  minEventHeight={0}
+  eventGap={0}
+  renderEvent={MyEvent}
+  onChangeDate={setDate}
+/>
+```
+
 ## The all-day lane
 
 All-day events (flagged `allDay`, or spanning midnight-to-midnight) leave the

--- a/docs/reference/api.mdx
+++ b/docs/reference/api.mdx
@@ -96,6 +96,8 @@ the [Date selection](/guides/selection) guide.
 | ---------------------- | ------------------------------------------ | ------------------------------------------------------------------------------- |
 | `scrollOffsetMinutes`  | `number`                                   | Initial vertical scroll.                                                        |
 | `hourHeight`           | `number`                                   | Row height (px per hour).                                                       |
+| `minEventHeight`       | `number`                                   | Time grid: floor on an event box's height and its `boxHeight` (default 32).     |
+| `eventGap`             | `number`                                   | Time grid: inset between an event box and its slot, per side (default 2).       |
 | `timeslots`            | `number`                                   | Hour sub-divisions.                                                             |
 | `ampm`                 | `boolean`                                  | 12-hour labels.                                                                 |
 | `showNowIndicator`     | `boolean`                                  | Current-time line (default on).                                                 |

--- a/packages/dom/src/Calendar.tsx
+++ b/packages/dom/src/Calendar.tsx
@@ -115,6 +115,17 @@ export interface CalendarProps<T = unknown>
   ampm?: boolean;
   /** Initial pixels per hour. */
   hourHeight?: number;
+  /**
+   * Minimum pixel height of a timed event box, so short events stay legible and
+   * clickable. Also the floor of the `boxHeight` handed to `renderTimeEvent`.
+   * Default 14; pass 0 to size every box strictly by its duration.
+   */
+  minEventHeight?: number;
+  /**
+   * Inset in pixels between a timed event box and its column edges (each side).
+   * Default 1; pass 0 to let events fill their column.
+   */
+  eventGap?: number;
   /** Initial scroll position, in minutes from midnight. */
   scrollOffsetMinutes?: number;
   /** Sub-divisions per hour for the grid lines. */
@@ -310,6 +321,8 @@ export function Calendar<T = unknown>({
   // time grid
   ampm,
   hourHeight,
+  minEventHeight,
+  eventGap,
   scrollOffsetMinutes,
   timeslots,
   minHour,
@@ -493,6 +506,8 @@ export function Calendar<T = unknown>({
         styles={styles}
         ampm={ampm}
         hourHeight={hourHeight}
+        minEventHeight={minEventHeight}
+        eventGap={eventGap}
         scrollOffsetMinutes={scrollOffsetMinutes}
         timeslots={timeslots}
         minHour={minHour}

--- a/packages/dom/src/TimeGrid.tsx
+++ b/packages/dom/src/TimeGrid.tsx
@@ -80,6 +80,12 @@ export type TimeGridSlot =
 
 const GUTTER_WIDTH = 56;
 const HOURS_PER_DAY = 24;
+// Floor for a timed event box's height, so a very short event still shows a
+// sliver of its chip. Overridable per grid via `minEventHeight`.
+const DEFAULT_MIN_EVENT_HEIGHT = 14;
+// Horizontal inset of each event box from its column edges. Overridable per grid
+// via `eventGap`.
+const DEFAULT_EVENT_GAP = 1;
 const clamp = (v: number, lo: number, hi: number) => Math.min(hi, Math.max(lo, v));
 
 // Edge auto-advance: how close to the day-columns edge (px) counts as "at the
@@ -151,6 +157,17 @@ export interface TimeGridProps<T = unknown> extends SlotStyleProps<TimeGridSlot>
   minHourHeight?: number;
   /** Upper bound for pixels per hour when zooming. */
   maxHourHeight?: number;
+  /**
+   * Minimum pixel height of a timed event box, so short events stay legible and
+   * clickable. Also the floor of the `boxHeight` handed to `renderEvent`. Default
+   * 14; pass 0 to size every box strictly by its duration.
+   */
+  minEventHeight?: number;
+  /**
+   * Inset in pixels between a timed event box and its column edges (each side).
+   * Default 1; pass 0 to let events fill their column.
+   */
+  eventGap?: number;
   /** Snap dragged events to this many minutes (default 15). */
   dragStepMinutes?: number;
   /** Render event time ranges in 12-hour AM/PM (default false, 24h). */
@@ -392,6 +409,8 @@ export function TimeGrid<T = unknown>({
   zoomable = true,
   minHourHeight = 24,
   maxHourHeight = 160,
+  minEventHeight = DEFAULT_MIN_EVENT_HEIGHT,
+  eventGap = DEFAULT_EVENT_GAP,
   dragStepMinutes = 15,
   ampm = false,
   timeslots = 1,
@@ -998,7 +1017,7 @@ export function TimeGrid<T = unknown>({
       event: dragged,
       mode,
       isAllDay: false,
-      boxHeight: Math.max(drag.spillHours * hourHeight, 14),
+      boxHeight: Math.max(drag.spillHours * hourHeight, minEventHeight),
       continuesBefore: true,
       continuesAfter: false,
       ampm,
@@ -1484,7 +1503,7 @@ export function TimeGrid<T = unknown>({
                   // them to the day, so the height doesn't jump on commit.
                   const boxHeight = Math.max(
                     Math.min(durationHours, HOURS_PER_DAY - startHours) * hourHeight,
-                    14,
+                    minEventHeight,
                   );
                   const widthPct = 100 / pe.columns;
                   const onPress = () => onPressEvent?.(pe.event);
@@ -1552,8 +1571,8 @@ export function TimeGrid<T = unknown>({
                           // is the renderer's concern: the built-in one clamps, and a
                           // custom renderer should adapt to the `boxHeight` it's given.
                           height: boxHeight,
-                          left: `calc(${pe.column * widthPct}% + 1px)`,
-                          width: `calc(${widthPct}% - 2px)`,
+                          left: `calc(${pe.column * widthPct}% + ${eventGap}px)`,
+                          width: `calc(${widthPct}% - ${eventGap * 2}px)`,
                           cursor: canMove ? "grab" : "pointer",
                           touchAction: canMove ? "none" : "auto",
                           zIndex: active ? 3 : 1,
@@ -1622,9 +1641,9 @@ export function TimeGrid<T = unknown>({
                       base: {
                         position: "absolute",
                         top: (moveSegment.startHours - windowStart) * hourHeight,
-                        left: 1,
-                        right: 1,
-                        height: Math.max(moveSegment.durationHours * hourHeight, 14),
+                        left: eventGap,
+                        right: eventGap,
+                        height: Math.max(moveSegment.durationHours * hourHeight, minEventHeight),
                         pointerEvents: "none",
                         zIndex: 3,
                         opacity: 0.85,
@@ -1636,7 +1655,7 @@ export function TimeGrid<T = unknown>({
                         event: moveSegment.event,
                         mode,
                         isAllDay: false,
-                        boxHeight: Math.max(moveSegment.durationHours * hourHeight, 14),
+                        boxHeight: Math.max(moveSegment.durationHours * hourHeight, minEventHeight),
                         continuesBefore: moveSegment.continuesBefore,
                         continuesAfter: moveSegment.continuesAfter,
                         ampm,
@@ -1662,8 +1681,8 @@ export function TimeGrid<T = unknown>({
                         // the preview is scrolled out of view, exactly like the
                         // continuation the drop will commit.
                         top: -windowStart * hourHeight,
-                        left: 1,
-                        right: 1,
+                        left: eventGap,
+                        right: eventGap,
                         height: spill.boxHeight,
                         pointerEvents: "none",
                         zIndex: 3,
@@ -1712,8 +1731,8 @@ export function TimeGrid<T = unknown>({
                     {...slot("createGhost", {
                       base: {
                         position: "absolute",
-                        left: 1,
-                        right: 1,
+                        left: eventGap,
+                        right: eventGap,
                         top: ghost.topPx,
                         height: Math.max(ghost.heightPx, 2),
                         opacity: 0.7,

--- a/packages/dom/src/__tests__/Calendar.test.tsx
+++ b/packages/dom/src/__tests__/Calendar.test.tsx
@@ -200,3 +200,27 @@ describe("Calendar hiddenDays forwarding", () => {
     expect(container.querySelectorAll('[data-slot="columnHeader"]')).toHaveLength(5);
   });
 });
+
+describe("Calendar event box sizing forwarding", () => {
+  it("passes minEventHeight and eventGap through to the time grid", () => {
+    // 15 minutes at 48px/hour is 12px; without the override it would be 14px.
+    const quarter: CalendarEvent[] = [
+      { title: "Quarter", start: new Date(2026, 6, 15, 9, 0), end: new Date(2026, 6, 15, 9, 15) },
+    ];
+    const { getByText } = render(
+      <Calendar
+        mode="day"
+        date={new Date(2026, 6, 15)}
+        events={quarter}
+        hourHeight={48}
+        minEventHeight={0}
+        eventGap={0}
+        renderTimeEvent={() => <div>Quarter</div>}
+      />,
+    );
+    const box = getByText("Quarter").parentElement as HTMLElement;
+    expect(box.style.height).toBe("12px");
+    expect(box.style.left).toBe("calc(0% + 0px)");
+    expect(box.style.width).toBe("calc(100% - 0px)");
+  });
+});

--- a/packages/dom/src/__tests__/TimeGrid.test.tsx
+++ b/packages/dom/src/__tests__/TimeGrid.test.tsx
@@ -1323,3 +1323,58 @@ describe("dom TimeGrid edge auto-advance", () => {
     }
   });
 });
+
+describe("dom TimeGrid event box sizing", () => {
+  // 15 minutes at 48px/hour is 12px, under the default 14px floor.
+  const quarter: CalendarEvent[] = [
+    { title: "Quarter", start: new Date(2026, 5, 26, 9, 0), end: new Date(2026, 5, 26, 9, 15) },
+  ];
+  const probe = () => {
+    const seen: number[] = [];
+    const ProbeEvent = ({ boxHeight }: { boxHeight?: number }) => {
+      if (boxHeight !== undefined) seen.push(boxHeight);
+      return <div>Quarter</div>;
+    };
+    return { ProbeEvent, seen };
+  };
+
+  it("floors a short event's box and boxHeight at 14px by default", () => {
+    const { ProbeEvent, seen } = probe();
+    const { getByText } = render(
+      <TimeGrid date={day} mode="day" events={quarter} hourHeight={48} renderEvent={ProbeEvent} />,
+    );
+    expect(getByText("Quarter").parentElement!.style.height).toBe("14px");
+    // The renderer may run more than once per mount; every call sees the floor.
+    expect(new Set(seen)).toEqual(new Set([14]));
+  });
+
+  it("minEventHeight lowers the floor so the box follows the duration", () => {
+    const { ProbeEvent, seen } = probe();
+    const { getByText } = render(
+      <TimeGrid
+        date={day}
+        mode="day"
+        events={quarter}
+        hourHeight={48}
+        renderEvent={ProbeEvent}
+        minEventHeight={0}
+      />,
+    );
+    expect(getByText("Quarter").parentElement!.style.height).toBe("12px");
+    expect(new Set(seen)).toEqual(new Set([12]));
+  });
+
+  it("insets the box by eventGap (default 1px) and lets 0 fill the column", () => {
+    const boxInset = (eventGap?: number) => {
+      const { getByText, unmount } = render(
+        <TimeGrid date={day} mode="day" events={events} hourHeight={48} eventGap={eventGap} />,
+      );
+      const { left, width } = wrapperOf(getByText("Focus")).style;
+      unmount();
+      return { left, width };
+    };
+    expect(boxInset()).toEqual({ left: "calc(0% + 1px)", width: "calc(100% - 2px)" });
+    expect(boxInset(0)).toEqual({ left: "calc(0% + 0px)", width: "calc(100% - 0px)" });
+    expect(boxInset(4)).toEqual({ left: "calc(0% + 4px)", width: "calc(100% - 8px)" });
+  });
+});

--- a/packages/native/src/components/Calendar.tsx
+++ b/packages/native/src/components/Calendar.tsx
@@ -217,6 +217,17 @@ export type CalendarProps<T> = SlotStyleProps<CalendarSlot> & {
   hourHeight?: number;
   minHourHeight?: number;
   maxHourHeight?: number;
+  /**
+   * Minimum pixel height of a timed event box on the week/day grid, so short
+   * events stay legible and tappable. Also the floor of the `boxHeight` handed to
+   * `renderEvent`. Default 32; pass 0 to size every box strictly by its duration.
+   */
+  minEventHeight?: number;
+  /**
+   * Inset in pixels between a timed event box and its slot on the week/day grid
+   * (each side). Default 2; pass 0 to let events fill their slot.
+   */
+  eventGap?: number;
   hourColumnWidth?: number;
   /** Hide the left hour-axis column on the week/day grid. Default false. */
   hideHours?: boolean;
@@ -451,6 +462,8 @@ export function Calendar<T>({
   hourHeight = DEFAULT_HOUR_HEIGHT,
   minHourHeight,
   maxHourHeight,
+  minEventHeight,
+  eventGap,
   hourColumnWidth,
   hideHours,
   timeslots,
@@ -709,6 +722,8 @@ export function Calendar<T>({
           ampm={ampm}
           minHourHeight={minHourHeight}
           maxHourHeight={maxHourHeight}
+          minEventHeight={minEventHeight}
+          eventGap={eventGap}
           showNowIndicator={showNowIndicator}
           locale={locale}
           activeDate={activeDate}

--- a/packages/native/src/components/MultiDayMovePreview.tsx
+++ b/packages/native/src/components/MultiDayMovePreview.tsx
@@ -32,10 +32,11 @@ type PreviewProps<T> = {
   minHour: number;
   mode: CalendarMode;
   renderEvent: RenderEvent<T>;
+  minEventHeight: number;
+  eventGap: number;
 };
 
 const noop = () => {};
-const MIN_EVENT_HEIGHT = 32;
 
 // Mount once on grab. Only numbers and shared values cross to the UI thread;
 // moving the pointer does not rerender the page or rebuild its gestures.
@@ -65,6 +66,8 @@ function PreviewDay<T>({
   minHour,
   mode,
   renderEvent: RenderEventComponent,
+  minEventHeight,
+  eventGap,
   dayOffsets,
   index,
   dayStart,
@@ -99,10 +102,12 @@ function PreviewDay<T>({
       continuesAfter: end > dayEnd,
     };
   }, [dayWidth, dayIndex, dayOffsets, startTimestamp, duration, dayStart, dayEnd]);
-  const boxHeight = useDerivedValue(() =>
-    segment.value.hours > 0
-      ? Math.max(segment.value.hours * cellHeight.value, MIN_EVENT_HEIGHT)
-      : 0,
+  const boxHeight = useDerivedValue(
+    () =>
+      segment.value.hours > 0
+        ? Math.max(segment.value.hours * cellHeight.value, minEventHeight)
+        : 0,
+    [minEventHeight],
   );
   const style = useAnimatedStyle(
     () => ({
@@ -143,7 +148,7 @@ function PreviewDay<T>({
         {
           position: "absolute",
           overflow: "hidden",
-          padding: 2,
+          padding: eventGap,
           left: hourColumnWidth + index * dayWidth,
           width: dayWidth,
           zIndex: 100,

--- a/packages/native/src/components/TimeGrid.tsx
+++ b/packages/native/src/components/TimeGrid.tsx
@@ -129,11 +129,13 @@ const DEFAULT_MIN_HOUR_HEIGHT = 32;
 const DEFAULT_MAX_HOUR_HEIGHT = 160;
 const DEFAULT_HOUR_COLUMN_WIDTH = 56;
 // Short events would otherwise render only a few pixels tall and clip their
-// content; keep them tall enough to stay legible and tappable.
-const MIN_EVENT_HEIGHT = 32;
+// content; keep them tall enough to stay legible and tappable. Overridable per
+// grid via `minEventHeight`.
+const DEFAULT_MIN_EVENT_HEIGHT = 32;
 // Inset each event box within its slot so adjacent boxes (and column edges) get a
-// little breathing room instead of butting edge-to-edge.
-const EVENT_GAP = 2;
+// little breathing room instead of butting edge-to-edge. Overridable per grid via
+// `eventGap`.
+const DEFAULT_EVENT_GAP = 2;
 // Hold this long before drag-to-create (sweeping empty grid space) begins on
 // native, so a normal scroll/tap isn't hijacked.
 const DRAG_ACTIVATE_MS = 300;
@@ -208,6 +210,7 @@ function MoveSpillPreview<T>({
   event,
   mode,
   renderEvent,
+  eventGap,
   slotProps,
 }: {
   spillHeight: SharedValue<number>;
@@ -220,6 +223,7 @@ function MoveSpillPreview<T>({
   event: CalendarEvent<T>;
   mode: CalendarMode;
   renderEvent: RenderEvent<T>;
+  eventGap: number;
   slotProps: ResolvedSlot<ViewStyle>;
 }): ReactElement {
   const RenderEventComponent = renderEvent;
@@ -246,7 +250,7 @@ function MoveSpillPreview<T>({
       style={[
         styles.eventBox,
         styles.nonInteractive,
-        { left: dayLeftPx, width: dayWidth, top: 0 },
+        { left: dayLeftPx, width: dayWidth, top: 0, padding: eventGap },
         slotProps.style,
         style,
       ]}
@@ -278,6 +282,7 @@ function DragGhost<T>({
   event,
   mode,
   renderEvent,
+  eventGap,
 }: {
   x: SharedValue<number>;
   y: SharedValue<number>;
@@ -287,6 +292,7 @@ function DragGhost<T>({
   event: CalendarEvent<T>;
   mode: CalendarMode;
   renderEvent: RenderEvent<T>;
+  eventGap: number;
 }): ReactElement {
   const RenderEventComponent = renderEvent;
   const style = useAnimatedStyle(() => ({
@@ -296,7 +302,10 @@ function DragGhost<T>({
     opacity: visible.value,
   }));
   return (
-    <Animated.View style={[styles.eventBox, styles.dragGhost, style]} pointerEvents="none">
+    <Animated.View
+      style={[styles.eventBox, styles.dragGhost, { padding: eventGap }, style]}
+      pointerEvents="none"
+    >
       <RenderEventComponent event={event} mode={mode} boxHeight={h} onPress={noop} />
     </Animated.View>
   );
@@ -341,6 +350,10 @@ type AnimatedEventBoxProps<T> = {
   daysPerPage: number;
   renderEvent: RenderEvent<T>;
   snapMinutes: number;
+  // Floor for the box's pixel height (and the `boxHeight` handed to renderEvent).
+  minEventHeight: number;
+  // Inset between the box and its slot, applied as border-box padding.
+  eventGap: number;
   onPress: (event: CalendarEvent<T>) => void;
   onLongPress?: (event: CalendarEvent<T>) => void;
   onDragEvent?: EventDragHandler<T>;
@@ -375,6 +388,8 @@ function AnimatedEventBox<T>({
   daysPerPage,
   renderEvent,
   snapMinutes,
+  minEventHeight,
+  eventGap,
   onPress,
   onLongPress,
   onDragEvent,
@@ -475,9 +490,9 @@ function AnimatedEventBox<T>({
     () =>
       Math.max(
         durationHours * cellHeight.value + resizeDelta.value - resizeStartDelta.value,
-        MIN_EVENT_HEIGHT,
+        minEventHeight,
       ),
-    [durationHours],
+    [durationHours, minEventHeight],
   );
 
   // The source segment may stop at midnight while the full event continues in
@@ -488,8 +503,8 @@ function AnimatedEventBox<T>({
     const top =
       (startHours - minHour) * cellHeight.value + moveOffset.value + resizeStartDelta.value;
     const dayEnd = (HOURS_PER_DAY - minHour) * cellHeight.value;
-    return Math.max(Math.min(boxHeight.value, dayEnd - top), MIN_EVENT_HEIGHT);
-  }, [startHours, minHour]);
+    return Math.max(Math.min(boxHeight.value, dayEnd - top), minEventHeight);
+  }, [startHours, minHour, minEventHeight]);
 
   const boxStyle = useAnimatedStyle(() => {
     // A top-edge resize pushes the box down and shortens it (start moves later).
@@ -985,7 +1000,7 @@ function AnimatedEventBox<T>({
     : undefined;
 
   const eventSlot = slot("event", {
-    base: [styles.eventBox, { left, width }],
+    base: [styles.eventBox, { left, width, padding: eventGap }],
     themed: theme.containers.timeGridEvent,
   });
   const box = (
@@ -1047,6 +1062,7 @@ function AnimatedEventBox<T>({
           event={positioned.event}
           mode={mode}
           renderEvent={renderEvent}
+          eventGap={eventGap}
           slotProps={slot("event", { themed: theme.containers.timeGridEvent })}
         />
       ) : null}
@@ -1264,6 +1280,8 @@ type TimetablePageProps<T> = {
   renderEvent: RenderEvent<T>;
   keyExtractor: EventKeyExtractor<T>;
   snapMinutes: number;
+  minEventHeight: number;
+  eventGap: number;
   showDragHandle: boolean;
   eventStartEditable: boolean;
   eventDurationEditable: boolean;
@@ -1321,6 +1339,8 @@ function TimetablePageInner<T>({
   renderEvent,
   keyExtractor,
   snapMinutes,
+  minEventHeight,
+  eventGap,
   showDragHandle,
   eventStartEditable,
   eventDurationEditable,
@@ -1679,7 +1699,7 @@ function TimetablePageInner<T>({
   }));
 
   const ghostSlot = slot("createGhost", {
-    base: [styles.createGhost, { pointerEvents: "none" }],
+    base: [styles.createGhost, { marginHorizontal: eventGap, pointerEvents: "none" }],
     themed: {
       backgroundColor: theme.colors.eventBackground,
       borderColor: theme.colors.todayBackground,
@@ -1900,6 +1920,8 @@ function TimetablePageInner<T>({
                       daysPerPage={daysPerPage}
                       renderEvent={renderEvent}
                       snapMinutes={snapMinutes}
+                      minEventHeight={minEventHeight}
+                      eventGap={eventGap}
                       showDragHandle={showDragHandle}
                       eventStartEditable={eventStartEditable}
                       eventDurationEditable={eventDurationEditable}
@@ -1923,6 +1945,8 @@ function TimetablePageInner<T>({
                 minHour={minHour}
                 mode={mode}
                 renderEvent={renderEvent}
+                minEventHeight={minEventHeight}
+                eventGap={eventGap}
               />
             ) : null}
 
@@ -2048,6 +2072,18 @@ export type TimeGridProps<T> = SlotStyleProps<TimeGridSlot> & {
   isRTL?: boolean;
   minHourHeight?: number;
   maxHourHeight?: number;
+  /**
+   * Minimum pixel height of a timed event box, so short events stay legible and
+   * tappable. Also the floor of the `boxHeight` handed to `renderEvent`. Default
+   * 32; pass 0 to size every box strictly by its duration.
+   */
+  minEventHeight?: number;
+  /**
+   * Inset in pixels between a timed event box and its slot (each side), so
+   * adjacent boxes and column edges get some breathing room. Default 2; pass 0
+   * to let events fill their slot.
+   */
+  eventGap?: number;
   showNowIndicator?: boolean;
   locale?: Locale;
   freeSwipe?: boolean;
@@ -2128,6 +2164,8 @@ function TimeGridInner<T>({
   isRTL = false,
   minHourHeight = DEFAULT_MIN_HOUR_HEIGHT,
   maxHourHeight = DEFAULT_MAX_HOUR_HEIGHT,
+  minEventHeight = DEFAULT_MIN_EVENT_HEIGHT,
+  eventGap = DEFAULT_EVENT_GAP,
   showNowIndicator = true,
   locale,
   freeSwipe = false,
@@ -2618,6 +2656,8 @@ function TimeGridInner<T>({
           renderEvent={labeledRenderEvent}
           keyExtractor={keyExtractor}
           snapMinutes={Math.max(1, dragStepMinutes)}
+          minEventHeight={minEventHeight}
+          eventGap={eventGap}
           showDragHandle={showDragHandle}
           eventStartEditable={eventStartEditable}
           eventDurationEditable={eventDurationEditable}
@@ -2668,6 +2708,8 @@ function TimeGridInner<T>({
       labeledRenderEvent,
       keyExtractor,
       dragStepMinutes,
+      minEventHeight,
+      eventGap,
       showDragHandle,
       eventStartEditable,
       eventDurationEditable,
@@ -2778,6 +2820,7 @@ function TimeGridInner<T>({
                 event={liftedEvent}
                 mode={mode}
                 renderEvent={labeledRenderEvent}
+                eventGap={eventGap}
               />
             ) : null}
           </View>
@@ -3019,7 +3062,6 @@ const styles = StyleSheet.create({
     position: "absolute",
     borderRadius: 6,
     borderWidth: StyleSheet.hairlineWidth,
-    marginHorizontal: EVENT_GAP,
   },
   weekendColumn: {
     position: "absolute",
@@ -3079,12 +3121,11 @@ const styles = StyleSheet.create({
     borderRadius: 2,
     opacity: 0.4,
   },
+  // The `eventGap` inset is applied inline as border-box padding, so the visible
+  // box (the flex child) sits inside the slot without touching its geometry.
   eventBox: {
     position: "absolute",
     overflow: "hidden",
-    // Border-box padding insets the visible box (the flex child) on all sides,
-    // giving a small gap without touching the slot geometry above.
-    padding: EVENT_GAP,
   },
   // The cross-week drag ghost: pinned to the pager's top-left, moved into place by
   // its transform, and floated above every page so it stays visible across a page.

--- a/packages/native/src/components/__tests__/TimeGrid.test.tsx
+++ b/packages/native/src/components/__tests__/TimeGrid.test.tsx
@@ -641,3 +641,89 @@ describe("TimeGrid slot styling", () => {
     expect(flat.color).toBe("tomato");
   });
 });
+
+describe("TimeGrid event box sizing", () => {
+  const date = new Date(2026, 0, 6, 12, 0, 0);
+  // 15 minutes at 48px/hour is 12px, well under the default 32px floor.
+  const quarter: CalendarEvent<WithId> = {
+    id: "quarter",
+    title: "Quarter",
+    start: new Date(2026, 0, 6, 9, 0, 0),
+    end: new Date(2026, 0, 6, 9, 15, 0),
+  };
+  const gridProps = () => ({
+    mode: "day" as const,
+    date,
+    events: [quarter],
+    cellHeight: { value: 48 } as never,
+    hourHeight: 48,
+    weekStartsOn: 1 as const,
+    keyExtractor: (item: CalendarEvent<WithId>) => item.id,
+    onChangeDate: noop,
+    onPressEvent: noop,
+  });
+  const probe = () => {
+    let observed: { value: number } | undefined;
+    const ProbeEvent = ({ boxHeight }: RenderEventArgs<WithId>) => {
+      observed = boxHeight;
+      return <Text>Quarter</Text>;
+    };
+    return { ProbeEvent, boxHeight: () => observed?.value };
+  };
+
+  it("floors a short event's boxHeight at 32px by default", () => {
+    const { ProbeEvent, boxHeight } = probe();
+    render(<TimeGrid {...gridProps()} renderEvent={ProbeEvent} />);
+    expect(boxHeight()).toBe(32);
+  });
+
+  it("minEventHeight lowers the floor so boxHeight follows the duration", () => {
+    const { ProbeEvent, boxHeight } = probe();
+    render(<TimeGrid {...gridProps()} renderEvent={ProbeEvent} minEventHeight={0} />);
+    expect(boxHeight()).toBe(12);
+  });
+
+  it("minEventHeight can raise the floor too", () => {
+    const { ProbeEvent, boxHeight } = probe();
+    render(<TimeGrid {...gridProps()} renderEvent={ProbeEvent} minEventHeight={40} />);
+    expect(boxHeight()).toBe(40);
+  });
+
+  it("insets the event box by eventGap (default 2) and lets 0 fill the slot", () => {
+    const boxPadding = (eventGap?: number) => {
+      const { UNSAFE_getAllByProps } = render(
+        <TimeGrid
+          {...gridProps()}
+          renderEvent={DefaultEvent}
+          classNames={{ event: "event-slot" }}
+          eventGap={eventGap}
+        />,
+      );
+      const [box] = UNSAFE_getAllByProps({ className: "event-slot" });
+      return (StyleSheet.flatten(box.props.style) as Record<string, unknown>).padding;
+    };
+    expect(boxPadding()).toBe(2);
+    expect(boxPadding(0)).toBe(0);
+    expect(boxPadding(6)).toBe(6);
+  });
+
+  it("Calendar forwards minEventHeight and eventGap to the grid", () => {
+    const { ProbeEvent, boxHeight } = probe();
+    const { UNSAFE_getAllByProps } = render(
+      <Calendar
+        mode="day"
+        date={date}
+        events={[quarter]}
+        renderEvent={ProbeEvent}
+        minEventHeight={0}
+        eventGap={0}
+        classNames={{ event: "event-slot" }}
+        onChangeDate={noop}
+        onPressEvent={noop}
+      />,
+    );
+    expect(boxHeight()).toBe(12);
+    const [box] = UNSAFE_getAllByProps({ className: "event-slot" });
+    expect((StyleSheet.flatten(box.props.style) as Record<string, unknown>).padding).toBe(0);
+  });
+});


### PR DESCRIPTION
Closes #54
Closes #55

## What

Two new `Calendar` / `TimeGrid` props on both renderers replace the hard-coded `MIN_EVENT_HEIGHT` and `EVENT_GAP` constants in the native time grid:

- `minEventHeight` sets the floor on a timed event box's pixel height. It is also the floor of the `boxHeight` handed to `renderEvent`, which is what #55 needs for custom appointment renderers. Pass `0` to size every box strictly by its duration.
- `eventGap` sets the inset between an event box and its slot on each side. Pass `0` to let events fill the full slot, which is what #54 asks for.

Defaults keep today's look on each renderer: native `32` / `2`, dom `14` / `1`. With both props set explicitly the two renderers produce identical geometry.

## Where it applies

- `minEventHeight` floors every rendered event box: resting boxes, the live drag/resize height, the midnight spill preview, the multi-day move preview (native), and the cross-page drag ghost (native). Every place the old hard-coded floor lived.
- `eventGap` insets those same boxes and, since it shares the old constant, also the drag-to-create ghost on both renderers.
- The drag-to-create ghost's height is unchanged: it previews the swept range and keeps its existing floor (one snap step on native, a 2px sliver on dom), so it is not affected by `minEventHeight`.

## Validation

- Unit tests on both renderers cover the default floor, lowering and raising it, the gap inset, and the `Calendar` pass-through. `pnpm lint`, `pnpm format`, `pnpm typecheck` (root and both examples), `pnpm test`, and `pnpm build` all pass; the renderer parity and docs-sync guards stay green.
- End-to-end in headless Chromium against both example apps (dom via Vite, native via Expo on react-native-web), measuring the rendered DOM for a 15-minute event and two overlapping events:

| renderer | scenario | box height | `boxHeight` arg | side inset | gap between neighbours |
| --- | --- | --- | --- | --- | --- |
| dom | defaults | 14 | 14 | 1 | 2 |
| dom | `minEventHeight={0} eventGap={0}` | 12 | 12 | 0 | 0 |
| dom | `minEventHeight={40} eventGap={6}` | 40 | 40 | 6 | 12 |
| native | defaults | 32 | 32 | 2 | 4 |
| native | `minEventHeight={0} eventGap={0}` | 12 | 12 | 0 | 0 |
| native | `minEventHeight={40} eventGap={6}` | 40 | 40 | 6 | 12 |

## Docs

`docs/guides/time-grid.mdx` gains an "Event boxes" section, `docs/reference/api.mdx` lists both props, and `docs/guides/events.mdx` notes that `boxHeight` is floored by `minEventHeight`.